### PR TITLE
zombienet warp sync grandpa

### DIFF
--- a/core/blockchain/impl/block_tree_impl.cpp
+++ b/core/blockchain/impl/block_tree_impl.cpp
@@ -1135,7 +1135,9 @@ namespace kagome::blockchain {
           auto count = to - from + 1;
           OUTCOME_TRY(chain,
                       getDescendingChainToBlockNoLock(p, descendant, count));
-          BOOST_ASSERT(chain.size() == count);
+          if (chain.size() != count) {
+            return BlockTreeError::EXISTING_BLOCK_NOT_FOUND;
+          }
           if (chain.back() != ancestor) {
             return BlockTreeError::BLOCK_ON_DEAD_END;
           }

--- a/core/consensus/timeline/impl/timeline_impl.cpp
+++ b/core/consensus/timeline/impl/timeline_impl.cpp
@@ -10,6 +10,7 @@
 #include "blockchain/block_tree.hpp"
 #include "clock/impl/clock_impl.hpp"
 #include "consensus/consensus_selector.hpp"
+#include "consensus/grandpa/justification_observer.hpp"
 #include "consensus/timeline/consistency_keeper.hpp"
 #include "consensus/timeline/impl/block_production_error.hpp"
 #include "consensus/timeline/slots_util.hpp"
@@ -663,7 +664,7 @@ namespace kagome::consensus {
               return;
             }
 
-            // self->justification_observer_->reload();
+            self->justification_observer_->reload();
             self->block_tree_->notifyBestAndFinalized();
 
             SL_INFO(self->log_,


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- `getChainByBlocks(from, to)` return error instead of assert
- fix regress `grandpa.reload()` after warp sync

### Benefits

### Possible Drawbacks