### PR TITLE
smoldot libp2p ws empty frame

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -40,7 +40,7 @@ hunter_config(
 
 hunter_config(
     libp2p
-    VERSION 0.1.15
+    VERSION 0.1.16
     KEEP_PACKAGE_SOURCES
 )
 

--- a/cmake/Hunter/hunter-gate-url.cmake
+++ b/cmake/Hunter/hunter-gate-url.cmake
@@ -1,5 +1,5 @@
 HunterGate(
-  URL  https://github.com/qdrvm/hunter/archive/refs/tags/v0.23.257-qdrvm8.tar.gz
-  SHA1 50901cca46cb26b6cedb8f67db0e562d3a1d4480
+  URL  https://github.com/qdrvm/hunter/archive/refs/tags/v0.23.257-qdrvm9.tar.gz
+  SHA1 6b27e02b400e2d32adb25d823b61ebcf0c7a13cb
   LOCAL
 )

--- a/core/network/helpers/stream_read_buffer.hpp
+++ b/core/network/helpers/stream_read_buffer.hpp
@@ -8,6 +8,9 @@
 
 #include "network/helpers/stream_proxy_base.hpp"
 
+#include <libp2p/basic/read_return_size.hpp>
+#include <libp2p/common/ambigous_size.hpp>
+
 namespace libp2p::connection {
   /**
    * Stream with buffered reader.
@@ -33,41 +36,9 @@ namespace libp2p::connection {
       return end - begin;
     }
 
-    /**
-     * Async loop iteration.
-     * Reads `out.size()` remaining bytes of `total` bytes.
-     */
-    void readFull(gsl::span<uint8_t> out, size_t total, ReadCallbackFunc cb) {
-      // read some bytes
-      readSome(
-          out,
-          out.size(),
-          [weak{weak_from_this()}, out, total, cb{std::move(cb)}](
-              outcome::result<size_t> bytes_num_res) mutable {
-            if (auto self{weak.lock()}) {
-              if (bytes_num_res.has_error()) {
-                return self->deferReadCallback(bytes_num_res.error(),
-                                               std::move(cb));
-              }
-              const auto &bytes_num = bytes_num_res.value();
-              BOOST_ASSERT(bytes_num != 0);
-              const auto bytes_num_ptrdiff{gsl::narrow<ptrdiff_t>(bytes_num)};
-              BOOST_ASSERT(bytes_num_ptrdiff <= out.size());
-              if (bytes_num_ptrdiff == out.size()) {
-                // successfully read last bytes
-                return self->deferReadCallback(total, std::move(cb));
-              }
-              // read remaining bytes
-              self->readFull(
-                  out.subspan(bytes_num_ptrdiff), total, std::move(cb));
-            }
-          });
-    }
-
     void read(gsl::span<uint8_t> out, size_t n, ReadCallbackFunc cb) override {
-      BOOST_ASSERT(out.size() >= gsl::narrow<ptrdiff_t>(n));
-      out = out.first(n);
-      readFull(out, n, std::move(cb));
+      libp2p::ambigousSize(out, n);
+      libp2p::readReturnSize(shared_from_this(), out, std::move(cb));
     }
 
     /**
@@ -87,8 +58,7 @@ namespace libp2p::connection {
     void readSome(gsl::span<uint8_t> out,
                   size_t n,
                   ReadCallbackFunc cb) override {
-      BOOST_ASSERT(out.size() >= gsl::narrow<ptrdiff_t>(n));
-      out = out.first(n);
+      libp2p::ambigousSize(out, n);
       if (out.empty()) {
         return deferReadCallback(out.size(), std::move(cb));
       }


### PR DESCRIPTION
### Referenced issues
- https://github.com/libp2p/cpp-libp2p/pull/218

### Description of the Change
- fix can't read smoldot ws messages

### Benefits

### Possible Drawbacks