### PR TITLE
weak io_context

### DIFF
--- a/core/blockchain/impl/block_tree_impl.cpp
+++ b/core/blockchain/impl/block_tree_impl.cpp
@@ -125,7 +125,7 @@ namespace kagome::blockchain {
       std::shared_ptr<const class JustificationStoragePolicy>
           justification_storage_policy,
       std::shared_ptr<storage::trie_pruner::TriePruner> state_pruner,
-      std::shared_ptr<::boost::asio::io_context> io_context) {
+      WeakIoContext io_context) {
     BOOST_ASSERT(storage != nullptr);
     BOOST_ASSERT(header_repo != nullptr);
 
@@ -420,7 +420,7 @@ namespace kagome::blockchain {
       std::shared_ptr<const JustificationStoragePolicy>
           justification_storage_policy,
       std::shared_ptr<storage::trie_pruner::TriePruner> state_pruner,
-      std::shared_ptr<::boost::asio::io_context> io_context)
+      WeakIoContext io_context)
       : block_tree_data_{BlockTreeData{
           .header_repo_ = std::move(header_repo),
           .storage_ = std::move(storage),

--- a/core/blockchain/impl/block_tree_impl.hpp
+++ b/core/blockchain/impl/block_tree_impl.hpp
@@ -60,7 +60,7 @@ namespace kagome::blockchain {
         std::shared_ptr<const class JustificationStoragePolicy>
             justification_storage_policy,
         std::shared_ptr<storage::trie_pruner::TriePruner> state_pruner,
-        std::shared_ptr<::boost::asio::io_context> io_context);
+        WeakIoContext io_context);
 
     /// Recover block tree state at provided block
     static outcome::result<void> recover(
@@ -193,7 +193,7 @@ namespace kagome::blockchain {
         std::shared_ptr<const class JustificationStoragePolicy>
             justification_storage_policy,
         std::shared_ptr<storage::trie_pruner::TriePruner> state_pruner,
-        std::shared_ptr<::boost::asio::io_context> io_context);
+        WeakIoContext io_context);
 
     outcome::result<void> reorgAndPrune(BlockTreeData &p,
                                         const ReorgAndPrune &changes);

--- a/core/consensus/babe/impl/babe.cpp
+++ b/core/consensus/babe/impl/babe.cpp
@@ -81,7 +81,7 @@ namespace kagome::consensus::babe {
       std::shared_ptr<network::BlockAnnounceTransmitter> announce_transmitter,
       std::shared_ptr<runtime::OffchainWorkerApi> offchain_worker_api,
       const ThreadPool &thread_pool,
-      std::shared_ptr<boost::asio::io_context> main_thread)
+      WeakIoContext main_thread)
       : log_(log::createLogger("Babe", "babe")),
         clock_(clock),
         block_tree_(std::move(block_tree)),
@@ -120,8 +120,6 @@ namespace kagome::consensus::babe {
     BOOST_ASSERT(chain_sub_engine_);
     BOOST_ASSERT(announce_transmitter_);
     BOOST_ASSERT(offchain_worker_api_);
-    BOOST_ASSERT(main_thread_);
-    BOOST_ASSERT(io_context_);
 
     // Register metrics
     metrics_registry_->registerGaugeFamily(
@@ -403,10 +401,10 @@ namespace kagome::consensus::babe {
           return;
         }
       };
-      self->main_thread_->post(std::move(proposed));
+      post(self->main_thread_, std::move(proposed));
     };
 
-    io_context_->post(std::move(propose));
+    post(io_context_, std::move(propose));
 
     return outcome::success();
   }

--- a/core/consensus/babe/impl/babe.hpp
+++ b/core/consensus/babe/impl/babe.hpp
@@ -17,10 +17,7 @@
 #include "primitives/block.hpp"
 #include "primitives/event_types.hpp"
 #include "telemetry/service.hpp"
-
-namespace boost::asio {
-  class io_context;
-}
+#include "utils/weak_io_context.hpp"
 
 namespace kagome {
   class ThreadPool;
@@ -110,7 +107,7 @@ namespace kagome::consensus::babe {
         std::shared_ptr<network::BlockAnnounceTransmitter> announce_transmitter,
         std::shared_ptr<runtime::OffchainWorkerApi> offchain_worker_api,
         const ThreadPool &thread_pool,
-        std::shared_ptr<boost::asio::io_context> main_thread);
+        WeakIoContext main_thread);
 
     bool isGenesisConsensus() const override;
 
@@ -167,8 +164,8 @@ namespace kagome::consensus::babe {
     primitives::events::ChainSubscriptionEnginePtr chain_sub_engine_;
     std::shared_ptr<network::BlockAnnounceTransmitter> announce_transmitter_;
     std::shared_ptr<runtime::OffchainWorkerApi> offchain_worker_api_;
-    std::shared_ptr<boost::asio::io_context> main_thread_;
-    std::shared_ptr<boost::asio::io_context> io_context_;
+    WeakIoContext main_thread_;
+    WeakIoContext io_context_;
 
     const bool is_validator_by_config_;
     bool is_active_validator_;

--- a/core/consensus/grandpa/impl/environment_impl.cpp
+++ b/core/consensus/grandpa/impl/environment_impl.cpp
@@ -43,7 +43,7 @@ namespace kagome::consensus::grandpa {
       std::shared_ptr<runtime::ParachainHost> parachain_api,
       std::shared_ptr<parachain::BackingStore> backing_store,
       std::shared_ptr<crypto::Hasher> hasher,
-      std::shared_ptr<boost::asio::io_context> main_thread_context)
+      WeakIoContext main_thread_context)
       : block_tree_{std::move(block_tree)},
         header_repository_{std::move(header_repository)},
         authority_manager_{std::move(authority_manager)},

--- a/core/consensus/grandpa/impl/environment_impl.hpp
+++ b/core/consensus/grandpa/impl/environment_impl.hpp
@@ -55,7 +55,7 @@ namespace kagome::consensus::grandpa {
         std::shared_ptr<runtime::ParachainHost> parachain_api,
         std::shared_ptr<parachain::BackingStore> backing_store,
         std::shared_ptr<crypto::Hasher> hasher,
-        std::shared_ptr<boost::asio::io_context> main_thread_context);
+        WeakIoContext main_thread_context);
 
     ~EnvironmentImpl() override = default;
 

--- a/core/consensus/grandpa/impl/grandpa_impl.cpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.cpp
@@ -70,7 +70,7 @@ namespace kagome::consensus::grandpa {
       std::shared_ptr<blockchain::BlockTree> block_tree,
       std::shared_ptr<network::ReputationRepository> reputation_repository,
       primitives::events::BabeStateSubscriptionEnginePtr babe_status_observable,
-      std::shared_ptr<boost::asio::io_context> main_thread_context)
+      WeakIoContext main_thread_context)
       : round_time_factor_{kGossipDuration},
         hasher_{std::move(hasher)},
         environment_{std::move(environment)},
@@ -87,7 +87,7 @@ namespace kagome::consensus::grandpa {
         main_thread_context_{std::move(main_thread_context)},
         scheduler_{std::make_shared<libp2p::basic::SchedulerImpl>(
             std::make_shared<libp2p::basic::AsioSchedulerBackend>(
-                internal_thread_context_->io_context()),
+                execution_thread_pool_->io_context()),
             libp2p::basic::Scheduler::Config{})} {
     BOOST_ASSERT(environment_ != nullptr);
     BOOST_ASSERT(crypto_provider_ != nullptr);

--- a/core/consensus/grandpa/impl/grandpa_impl.hpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.hpp
@@ -102,7 +102,7 @@ namespace kagome::consensus::grandpa {
         std::shared_ptr<network::ReputationRepository> reputation_repository,
         primitives::events::BabeStateSubscriptionEnginePtr
             babe_status_observable,
-        std::shared_ptr<boost::asio::io_context> main_thread_context);
+        WeakIoContext main_thread_context);
 
     /**
      * Prepares for grandpa round execution: e.g. sets justification observer

--- a/core/consensus/timeline/impl/block_executor_impl.cpp
+++ b/core/consensus/timeline/impl/block_executor_impl.cpp
@@ -31,7 +31,7 @@ namespace kagome::consensus {
   BlockExecutorImpl::BlockExecutorImpl(
       std::shared_ptr<blockchain::BlockTree> block_tree,
       const ThreadPool &thread_pool,
-      std::shared_ptr<boost::asio::io_context> main_thread,
+      WeakIoContext main_thread,
       std::shared_ptr<runtime::Core> core,
       std::shared_ptr<transaction_pool::TransactionPool> tx_pool,
       std::shared_ptr<crypto::Hasher> hasher,
@@ -179,9 +179,9 @@ namespace kagome::consensus {
                                  start_time,
                                  previous_best_block);
       };
-      main_thread_->post(std::move(executed));
+      post(main_thread_, std::move(executed));
     };
-    io_context_->post(std::move(execute));
+    post(io_context_, std::move(execute));
   }
 
   void BlockExecutorImpl::applyBlockExecuted(

--- a/core/consensus/timeline/impl/block_executor_impl.hpp
+++ b/core/consensus/timeline/impl/block_executor_impl.hpp
@@ -15,10 +15,7 @@
 #include "primitives/block_header.hpp"
 #include "primitives/event_types.hpp"
 #include "telemetry/service.hpp"
-
-namespace boost::asio {
-  class io_context;
-}
+#include "utils/weak_io_context.hpp"
 
 namespace kagome {
   class ThreadPool;
@@ -52,7 +49,7 @@ namespace kagome::consensus {
     BlockExecutorImpl(
         std::shared_ptr<blockchain::BlockTree> block_tree,
         const ThreadPool &thread_pool,
-        std::shared_ptr<boost::asio::io_context> main_thread,
+        WeakIoContext main_thread,
         std::shared_ptr<runtime::Core> core,
         std::shared_ptr<transaction_pool::TransactionPool> tx_pool,
         std::shared_ptr<crypto::Hasher> hasher,
@@ -78,8 +75,8 @@ namespace kagome::consensus {
         const primitives::BlockInfo &previous_best_block);
 
     std::shared_ptr<blockchain::BlockTree> block_tree_;
-    std::shared_ptr<boost::asio::io_context> io_context_;
-    std::shared_ptr<boost::asio::io_context> main_thread_;
+    WeakIoContext io_context_;
+    WeakIoContext main_thread_;
     std::shared_ptr<runtime::Core> core_;
     std::shared_ptr<transaction_pool::TransactionPool> tx_pool_;
     std::shared_ptr<crypto::Hasher> hasher_;

--- a/core/dispute_coordinator/impl/dispute_coordinator_impl.cpp
+++ b/core/dispute_coordinator/impl/dispute_coordinator_impl.cpp
@@ -119,7 +119,7 @@ namespace kagome::dispute {
       std::shared_ptr<parachain::Pvf> pvf,
       std::shared_ptr<parachain::ApprovalDistribution> approval_distribution,
       std::shared_ptr<authority_discovery::Query> authority_discovery,
-      std::shared_ptr<boost::asio::io_context> main_thread_context,
+      WeakIoContext main_thread_context,
       std::shared_ptr<network::Router> router,
       std::shared_ptr<network::PeerView> peer_view,
       std::shared_ptr<primitives::events::BabeStateSubscriptionEngine>
@@ -2161,7 +2161,7 @@ namespace kagome::dispute {
 
   void DisputeCoordinatorImpl::make_task_for_next_portion() {
     if (not rate_limit_timer_.has_value()) {
-      rate_limit_timer_.emplace(internal_context_->io_context());
+      rate_limit_timer_.emplace(int_pool_->io_context());
 
       rate_limit_timer_->expiresAfter(kReceiveRateLimit);
       rate_limit_timer_->asyncWait([wp = weak_from_this()](auto &&ec) {
@@ -2173,9 +2173,7 @@ namespace kagome::dispute {
                      ec);
             return;
           }
-          BOOST_ASSERT(self->internal_context_->io_context()
-                           ->get_executor()
-                           .running_in_this_thread());
+          BOOST_ASSERT(self->internal_context_->isInCurrentThread());
           self->process_portion_incoming_disputes();
         }
       });

--- a/core/dispute_coordinator/impl/dispute_coordinator_impl.hpp
+++ b/core/dispute_coordinator/impl/dispute_coordinator_impl.hpp
@@ -9,7 +9,6 @@
 #include "dispute_coordinator/dispute_coordinator.hpp"
 #include "network/dispute_request_observer.hpp"
 
-#include <boost/asio/io_context.hpp>
 #include <list>
 
 #include "clock/impl/basic_waitable_timer.hpp"
@@ -30,6 +29,7 @@
 #include "network/peer_view.hpp"
 #include "parachain/types.hpp"
 #include "primitives/authority_discovery_id.hpp"
+#include "utils/weak_io_context.hpp"
 
 namespace kagome {
   class ThreadPool;
@@ -112,7 +112,7 @@ namespace kagome::dispute {
         std::shared_ptr<parachain::Pvf> pvf,
         std::shared_ptr<parachain::ApprovalDistribution> approval_distribution,
         std::shared_ptr<authority_discovery::Query> authority_discovery,
-        std::shared_ptr<boost::asio::io_context> main_thread_context,
+        WeakIoContext main_thread_context,
         std::shared_ptr<network::Router> router,
         std::shared_ptr<network::PeerView> peer_view,
         primitives::events::BabeStateSubscriptionEnginePtr

--- a/core/network/beefy/beefy.cpp
+++ b/core/network/beefy/beefy.cpp
@@ -21,6 +21,7 @@
 #include "storage/spaced_storage.hpp"
 #include "utils/block_number_key.hpp"
 #include "utils/thread_pool.hpp"
+#include "utils/weak_io_context_strand.hpp"
 
 // TODO(turuslan): #1651, report equivocation
 
@@ -41,7 +42,7 @@ namespace kagome::network {
                std::shared_ptr<crypto::EcdsaProvider> ecdsa,
                std::shared_ptr<storage::SpacedStorage> db,
                std::shared_ptr<ThreadPool> thread_pool,
-               std::shared_ptr<boost::asio::io_context> main_thread,
+               WeakIoContext main_thread,
                LazySPtr<consensus::Timeline> timeline,
                std::shared_ptr<crypto::SessionKeys> session_keys,
                LazySPtr<BeefyProtocol> beefy_protocol,
@@ -50,8 +51,8 @@ namespace kagome::network {
         beefy_api_{std::move(beefy_api)},
         ecdsa_{std::move(ecdsa)},
         db_{db->getSpace(storage::Space::kBeefyJustification)},
-        strand_inner_{thread_pool->io_context()},
-        strand_{*strand_inner_},
+        strand_{
+            std::make_shared<WeakIoContextStrand>(thread_pool->io_context())},
         main_thread_{std::move(main_thread)},
         timeline_{std::move(timeline)},
         session_keys_{std::move(session_keys)},
@@ -81,7 +82,7 @@ namespace kagome::network {
 
   void Beefy::onJustification(const primitives::BlockHash &block_hash,
                               primitives::Justification raw) {
-    strand_.post([weak = weak_from_this(), block_hash, raw = std::move(raw)] {
+    strand_->post([weak = weak_from_this(), block_hash, raw = std::move(raw)] {
       if (auto self = weak.lock()) {
         std::ignore = self->onJustificationOutcome(block_hash, std::move(raw));
       }
@@ -105,14 +106,14 @@ namespace kagome::network {
   }
 
   void Beefy::onMessage(consensus::beefy::BeefyGossipMessage message) {
-    if (not strand_.running_in_this_thread()) {
-      return strand_.post(
-          [weak = weak_from_this(), message = std::move(message)] {
-            if (auto self = weak.lock()) {
-              self->onMessage(std::move(message));
-            }
-          });
-    }
+    strand_->post([weak = weak_from_this(), message = std::move(message)] {
+      if (auto self = weak.lock()) {
+        self->onMessageStrand(std::move(message));
+      }
+    });
+  }
+
+  void Beefy::onMessageStrand(consensus::beefy::BeefyGossipMessage message) {
     if (not beefy_genesis_) {
       return;
     }
@@ -184,7 +185,8 @@ namespace kagome::network {
     if (count >= consensus::beefy::threshold(total)) {
       std::ignore = apply(session.rounds.extract(round).mapped(), true);
     } else if (broadcast) {
-      main_thread_->post(
+      post(
+          main_thread_,
           [protocol{beefy_protocol_.get()},
            message{std::make_shared<consensus::beefy::BeefyGossipMessage>(
                std::move(vote))}] { protocol->broadcast(std::move(message)); });
@@ -201,14 +203,14 @@ namespace kagome::network {
     SL_INFO(log_, "last finalized {}", beefy_finalized_);
     chain_sub_.onFinalize([weak{weak_from_this()}]() {
       if (auto self = weak.lock()) {
-        self->strand_.post([weak] {
+        self->strand_->post([weak] {
           if (auto self = weak.lock()) {
             std::ignore = self->update();
           }
         });
       }
     });
-    strand_.post([weak = weak_from_this()] {
+    strand_->post([weak = weak_from_this()] {
       if (auto self = weak.lock()) {
         std::ignore = self->update();
       }
@@ -330,12 +332,12 @@ namespace kagome::network {
     metric_finalized->set(beefy_finalized_);
     next_digest_ = std::max(next_digest_, block_number + 1);
     if (broadcast) {
-      main_thread_->post(
-          [protocol{beefy_protocol_.get()},
-           message{std::make_shared<consensus::beefy::BeefyGossipMessage>(
-               std::move(justification_v1))}] {
-            protocol->broadcast(std::move(message));
-          });
+      post(main_thread_,
+           [protocol{beefy_protocol_.get()},
+            message{std::make_shared<consensus::beefy::BeefyGossipMessage>(
+                std::move(justification_v1))}] {
+             protocol->broadcast(std::move(message));
+           });
     }
     return outcome::success();
   }

--- a/core/network/beefy/beefy.hpp
+++ b/core/network/beefy/beefy.hpp
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <boost/asio/io_context_strand.hpp>
 #include <map>
 
 #include "consensus/beefy/types.hpp"
@@ -16,9 +15,11 @@
 #include "primitives/event_types.hpp"
 #include "primitives/justification.hpp"
 #include "storage/buffer_map_types.hpp"
+#include "utils/weak_io_context.hpp"
 
 namespace kagome {
   class ThreadPool;
+  class WeakIoContextStrand;
 }  // namespace kagome
 
 namespace kagome::application {
@@ -59,7 +60,7 @@ namespace kagome::network {
           std::shared_ptr<crypto::EcdsaProvider> ecdsa,
           std::shared_ptr<storage::SpacedStorage> db,
           std::shared_ptr<ThreadPool> thread_pool,
-          std::shared_ptr<boost::asio::io_context> main_thread,
+          WeakIoContext main_thread,
           LazySPtr<consensus::Timeline> timeline,
           std::shared_ptr<crypto::SessionKeys> session_keys,
           LazySPtr<BeefyProtocol> beefy_protocol,
@@ -93,6 +94,7 @@ namespace kagome::network {
         const primitives::BlockHash &block_hash, primitives::Justification raw);
     outcome::result<void> onJustification(
         consensus::beefy::SignedCommitment justification);
+    void onMessageStrand(consensus::beefy::BeefyGossipMessage message);
     void onVote(consensus::beefy::VoteMessage vote, bool broadcast);
     outcome::result<void> apply(
         consensus::beefy::SignedCommitment justification, bool broadcast);
@@ -104,9 +106,8 @@ namespace kagome::network {
     std::shared_ptr<runtime::BeefyApi> beefy_api_;
     std::shared_ptr<crypto::EcdsaProvider> ecdsa_;
     std::shared_ptr<storage::BufferStorage> db_;
-    std::shared_ptr<boost::asio::io_context> strand_inner_;
-    boost::asio::io_context::strand strand_;
-    std::shared_ptr<boost::asio::io_context> main_thread_;
+    std::shared_ptr<WeakIoContextStrand> strand_;
+    WeakIoContext main_thread_;
     LazySPtr<consensus::Timeline> timeline_;
     std::shared_ptr<crypto::SessionKeys> session_keys_;
     LazySPtr<BeefyProtocol> beefy_protocol_;

--- a/core/network/impl/protocols/propagate_transactions_protocol.hpp
+++ b/core/network/impl/protocols/propagate_transactions_protocol.hpp
@@ -27,6 +27,7 @@
 #include "subscription/subscriber.hpp"
 #include "subscription/subscription_engine.hpp"
 #include "utils/non_copyable.hpp"
+#include "utils/weak_io_context.hpp"
 
 namespace kagome::blockchain {
   class GenesisBlockHash;
@@ -55,7 +56,7 @@ namespace kagome::network {
         Roles roles,
         const application::ChainSpec &chain_spec,
         const blockchain::GenesisBlockHash &genesis_hash,
-        std::shared_ptr<boost::asio::io_context> main_thread,
+        WeakIoContext main_thread,
         std::shared_ptr<consensus::Timeline> timeline,
         std::shared_ptr<ExtrinsicObserver> extrinsic_observer,
         std::shared_ptr<StreamEngine> stream_engine,
@@ -81,7 +82,7 @@ namespace kagome::network {
         "PropagateTransactionsProtocol"s;
     ProtocolBaseImpl base_;
     Roles roles_;
-    std::shared_ptr<boost::asio::io_context> main_thread_;
+    WeakIoContext main_thread_;
     std::shared_ptr<consensus::Timeline> timeline_;
     std::shared_ptr<ExtrinsicObserver> extrinsic_observer_;
     std::shared_ptr<StreamEngine> stream_engine_;

--- a/core/parachain/approval/approval_distribution.hpp
+++ b/core/parachain/approval/approval_distribution.hpp
@@ -286,7 +286,7 @@ namespace kagome::parachain {
         std::shared_ptr<blockchain::BlockTree> block_tree,
         std::shared_ptr<parachain::Pvf> pvf,
         std::shared_ptr<parachain::Recovery> recovery,
-        std::shared_ptr<boost::asio::io_context> this_context,
+        WeakIoContext this_context,
         LazySPtr<dispute::DisputeCoordinator> dispute_coordinator);
     ~ApprovalDistribution() = default;
 
@@ -339,7 +339,6 @@ namespace kagome::parachain {
       std::optional<consensus::Randomness> randomness;
       std::optional<consensus::babe::Authorities> authorities;
 
-      std::shared_ptr<boost::asio::io_context> complete_callback_context;
       std::function<void(outcome::result<ImportedBlockInfo> &&)>
           complete_callback;
 

--- a/core/parachain/validator/impl/parachain_processor.cpp
+++ b/core/parachain/validator/impl/parachain_processor.cpp
@@ -68,7 +68,7 @@ namespace kagome::parachain {
       std::shared_ptr<dispute::RuntimeInfo> runtime_info,
       std::shared_ptr<crypto::Sr25519Provider> crypto_provider,
       std::shared_ptr<network::Router> router,
-      std::shared_ptr<boost::asio::io_context> this_context,
+      WeakIoContext this_context,
       std::shared_ptr<crypto::Hasher> hasher,
       std::shared_ptr<network::PeerView> peer_view,
       std::shared_ptr<ThreadPool> thread_pool,
@@ -103,11 +103,10 @@ namespace kagome::parachain {
         app_config_(app_config),
         babe_status_observable_(std::move(babe_status_observable)),
         query_audi_{std::move(query_audi)},
-        thread_handler_{thread_pool_->handler()} {
+        thread_handler_{thread_pool_->io_context()} {
     BOOST_ASSERT(pm_);
     BOOST_ASSERT(peer_view_);
     BOOST_ASSERT(crypto_provider_);
-    BOOST_ASSERT(this_context_);
     BOOST_ASSERT(router_);
     BOOST_ASSERT(hasher_);
     BOOST_ASSERT(thread_pool_);
@@ -233,8 +232,7 @@ namespace kagome::parachain {
                                  const network::ExView &event) {
           if (auto self = wptr.lock()) {
             /// clear caches
-            BOOST_ASSERT(
-                self->this_context_->get_executor().running_in_this_thread());
+            BOOST_ASSERT(runningInThisThread(self->this_context_));
 
             self->our_current_state_.active_leaves.exclusiveAccess(
                 [&](auto &active_leaves) {
@@ -302,7 +300,6 @@ namespace kagome::parachain {
   }
 
   bool ParachainProcessorImpl::start() {
-    thread_handler_->start();
     return true;
   }
 
@@ -376,7 +373,7 @@ namespace kagome::parachain {
 
   void ParachainProcessorImpl::createBackingTask(
       const primitives::BlockHash &relay_parent) {
-    BOOST_ASSERT(this_context_->get_executor().running_in_this_thread());
+    BOOST_ASSERT(runningInThisThread(this_context_));
     auto rps_result = initNewBackingTask(relay_parent);
     if (rps_result.has_value()) {
       storeStateByRelayParent(relay_parent, std::move(rps_result.value()));
@@ -565,7 +562,7 @@ namespace kagome::parachain {
       RelayParentState &parachain_state) {
     const auto candidate_hash{candidateHashFrom(attesting_data.candidate)};
 
-    BOOST_ASSERT(this_context_->get_executor().running_in_this_thread());
+    BOOST_ASSERT(runningInThisThread(this_context_));
     if (!parachain_state.awaiting_validation.insert(candidate_hash).second) {
       return;
     }
@@ -668,7 +665,7 @@ namespace kagome::parachain {
       RelayParentState &parachain_state,
       const primitives::BlockHash &candidate_hash,
       size_t n_validators) {
-    BOOST_ASSERT(this_context_->get_executor().running_in_this_thread());
+    BOOST_ASSERT(runningInThisThread(this_context_));
     parachain_state.awaiting_validation.insert(candidate_hash);
 
     logger_->info(
@@ -679,70 +676,70 @@ namespace kagome::parachain {
         peer_id);
 
     sequenceIgnore(
-        thread_handler_->io_context()->wrap(
-            asAsync([wself{weak_from_this()},
-                     candidate{std::move(candidate)},
-                     pov{std::move(pov)},
-                     peer_id,
-                     relay_parent,
-                     n_validators]() mutable
-                    -> outcome::result<
-                        ParachainProcessorImpl::ValidateAndSecondResult> {
-              if (auto self = wself.lock()) {
-                if (auto result =
-                        self->validateAndMakeAvailable(std::move(candidate),
-                                                       std::move(pov),
-                                                       peer_id,
-                                                       relay_parent,
-                                                       n_validators);
-                    result.has_error()) {
-                  self->logger_->warn("Validation task failed.(error={})",
-                                      result.error().message());
-                  return result.as_failure();
-                } else {
-                  return result;
-                }
-              }
-              return Error::NO_INSTANCE;
-            })),
-        this_context_->wrap(
-            asAsync([wself{weak_from_this()}, peer_id, candidate_hash](
-                        auto &&validate_and_second_result) mutable
-                    -> outcome::result<void> {
-              if (auto self = wself.lock()) {
-                auto parachain_state = self->tryGetStateByRelayParent(
-                    validate_and_second_result.relay_parent);
-                if (!parachain_state) {
-                  self->logger_->warn(
-                      "After validation no parachain state on relay_parent {}",
-                      validate_and_second_result.relay_parent);
-                  return Error::OUT_OF_VIEW;
-                }
+        wrap(thread_handler_,
+             asAsync([wself{weak_from_this()},
+                      candidate{std::move(candidate)},
+                      pov{std::move(pov)},
+                      peer_id,
+                      relay_parent,
+                      n_validators]() mutable
+                     -> outcome::result<
+                         ParachainProcessorImpl::ValidateAndSecondResult> {
+               if (auto self = wself.lock()) {
+                 if (auto result =
+                         self->validateAndMakeAvailable(std::move(candidate),
+                                                        std::move(pov),
+                                                        peer_id,
+                                                        relay_parent,
+                                                        n_validators);
+                     result.has_error()) {
+                   self->logger_->warn("Validation task failed.(error={})",
+                                       result.error().message());
+                   return result.as_failure();
+                 } else {
+                   return result;
+                 }
+               }
+               return Error::NO_INSTANCE;
+             })),
+        wrap(this_context_,
+             asAsync([wself{weak_from_this()}, peer_id, candidate_hash](
+                         auto &&validate_and_second_result) mutable
+                     -> outcome::result<void> {
+               if (auto self = wself.lock()) {
+                 auto parachain_state = self->tryGetStateByRelayParent(
+                     validate_and_second_result.relay_parent);
+                 if (!parachain_state) {
+                   self->logger_->warn(
+                       "After validation no parachain state on relay_parent {}",
+                       validate_and_second_result.relay_parent);
+                   return Error::OUT_OF_VIEW;
+                 }
 
-                self->logger_->info(
-                    "Async validation complete.(relay parent={}, para_id={})",
-                    validate_and_second_result.relay_parent,
-                    validate_and_second_result.candidate.descriptor.para_id);
+                 self->logger_->info(
+                     "Async validation complete.(relay parent={}, para_id={})",
+                     validate_and_second_result.relay_parent,
+                     validate_and_second_result.candidate.descriptor.para_id);
 
-                parachain_state->get().awaiting_validation.erase(
-                    candidate_hash);
-                auto q{std::move(validate_and_second_result)};
-                if constexpr (kMode == ValidationTaskType::kSecond) {
-                  self->onValidationComplete(peer_id, std::move(q));
-                } else {
-                  self->onAttestComplete(peer_id, std::move(q));
-                }
-                return outcome::success();
-              }
-              return Error::NO_INSTANCE;
-            })));
+                 parachain_state->get().awaiting_validation.erase(
+                     candidate_hash);
+                 auto q{std::move(validate_and_second_result)};
+                 if constexpr (kMode == ValidationTaskType::kSecond) {
+                   self->onValidationComplete(peer_id, std::move(q));
+                 } else {
+                   self->onAttestComplete(peer_id, std::move(q));
+                 }
+                 return outcome::success();
+               }
+               return Error::NO_INSTANCE;
+             })));
   }
 
   std::optional<
       std::reference_wrapper<ParachainProcessorImpl::RelayParentState>>
   ParachainProcessorImpl::tryGetStateByRelayParent(
       const primitives::BlockHash &relay_parent) {
-    BOOST_ASSERT(this_context_->get_executor().running_in_this_thread());
+    BOOST_ASSERT(runningInThisThread(this_context_));
     const auto it = our_current_state_.state_by_relay_parent.find(relay_parent);
     if (it != our_current_state_.state_by_relay_parent.end()) {
       return it->second;
@@ -753,7 +750,7 @@ namespace kagome::parachain {
   ParachainProcessorImpl::RelayParentState &
   ParachainProcessorImpl::storeStateByRelayParent(
       const primitives::BlockHash &relay_parent, RelayParentState &&val) {
-    BOOST_ASSERT(this_context_->get_executor().running_in_this_thread());
+    BOOST_ASSERT(runningInThisThread(this_context_));
     const auto &[it, inserted] =
         our_current_state_.state_by_relay_parent.insert(
             {relay_parent, std::move(val)});
@@ -765,7 +762,7 @@ namespace kagome::parachain {
       const libp2p::peer::PeerId &peer_id,
       const primitives::BlockHash &relay_parent,
       const network::SignedStatement &statement) {
-    BOOST_ASSERT(this_context_->get_executor().running_in_this_thread());
+    BOOST_ASSERT(runningInThisThread(this_context_));
     auto opt_parachain_state = tryGetStateByRelayParent(relay_parent);
     if (!opt_parachain_state) {
       logger_->trace(
@@ -1278,7 +1275,7 @@ namespace kagome::parachain {
   outcome::result<void> ParachainProcessorImpl::advCanBeProcessed(
       const primitives::BlockHash &relay_parent,
       const libp2p::peer::PeerId &peer_id) {
-    BOOST_ASSERT(this_context_->get_executor().running_in_this_thread());
+    BOOST_ASSERT(runningInThisThread(this_context_));
     OUTCOME_TRY(canProcessParachains());
 
     auto rps = our_current_state_.state_by_relay_parent.find(relay_parent);

--- a/core/utils/weak_io_context.hpp
+++ b/core/utils/weak_io_context.hpp
@@ -1,0 +1,16 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <memory>
+
+namespace boost::asio {
+  class io_context;
+}  // namespace boost::asio
+
+namespace kagome {
+  using WeakIoContext = std::weak_ptr<boost::asio::io_context>;
+}  // namespace kagome

--- a/core/utils/weak_io_context_post.hpp
+++ b/core/utils/weak_io_context_post.hpp
@@ -1,0 +1,32 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <boost/asio/io_context.hpp>
+
+#include "utils/weak_io_context.hpp"
+
+namespace kagome {
+  void post(const WeakIoContext &weak, auto f) {
+    if (auto io = weak.lock()) {
+      io->post(std::move(f));
+    }
+  }
+
+  inline bool runningInThisThread(const WeakIoContext &weak) {
+    auto io = weak.lock();
+    return io and io->get_executor().running_in_this_thread();
+  }
+
+  auto wrap(const WeakIoContext &weak, auto f) {
+    return [weak, f{std::move(f)}](auto &&...a) mutable {
+      post(weak,
+           [f{std::move(f)}, ... a{std::forward<decltype(a)>(a)}]() mutable {
+             f(std::forward<decltype(a)>(a)...);
+           });
+    };
+  }
+}  // namespace kagome

--- a/core/utils/weak_io_context_strand.hpp
+++ b/core/utils/weak_io_context_strand.hpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <deque>
+#include <functional>
+#include <libp2p/common/final_action.hpp>
+#include <mutex>
+
+#include "utils/weak_io_context_post.hpp"
+
+namespace kagome {
+  class WeakIoContextStrand
+      : public std::enable_shared_from_this<WeakIoContextStrand> {
+   public:
+    WeakIoContextStrand(WeakIoContext io) : io_{std::move(io)} {}
+
+    void post(auto f) {
+      kagome::post(io_, [weak{weak_from_this()}, f{std::move(f)}]() mutable {
+        if (auto self = weak.lock()) {
+          self->work(std::move(f));
+        }
+      });
+    }
+
+   private:
+    void work(auto &&f) {
+      std::unique_lock lock{mutex_};
+      if (running_) {
+        queue_.emplace_back(std::move(f));
+        return;
+      }
+      running_ = true;
+      libp2p::common::FinalAction BOOST_OUTCOME_TRY_UNIQUE_NAME{[&] {
+        if (not lock.owns_lock()) {
+          lock.lock();
+        }
+        running_ = false;
+      }};
+      lock.unlock();
+      f();
+      lock.lock();
+      while (not queue_.empty()) {
+        auto f = std::move(queue_.front());
+        queue_.pop_front();
+        lock.unlock();
+        f();
+        lock.lock();
+      }
+    }
+
+    WeakIoContext io_;
+    std::mutex mutex_;
+    bool running_ = false;
+    std::deque<std::function<void()>> queue_;
+  };
+}  // namespace kagome


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- use `weak_ptr<io_context>`

### Benefits
- reduce `shared_ptr` cyclic references (leaked mock objects)

### Possible Drawbacks
- move to libp2p?
- maybe make `WeakIoContextExecutor` to use with asio objects
- maybe `throw ShuttingDown` from `post`/`runningInThisThread`?