### PR TITLE
Return error from PolkadotTrieImpl::tryGet when failed to retrieve a value

### DIFF
--- a/core/runtime/wasm_edge/register_host_api.hpp
+++ b/core/runtime/wasm_edge/register_host_api.hpp
@@ -71,9 +71,10 @@ namespace kagome::runtime::wasm_edge {
   };
 
   template <typename F, typename... Args, size_t... Idxs>
-  decltype(auto) call_with_array(F f,
-                                 std::span<const WasmEdge_Value> array,
-                                 std::index_sequence<Idxs...>) {
+  decltype(auto) call_with_array(
+      F f,
+      [[maybe_unused]] std::span<const WasmEdge_Value> array,
+      std::index_sequence<Idxs...>) {
     return f(get_wasm_value<Args>(array[Idxs])...);
   }
 

--- a/core/storage/trie/polkadot_trie/polkadot_trie_impl.cpp
+++ b/core/storage/trie/polkadot_trie/polkadot_trie_impl.cpp
@@ -490,6 +490,9 @@ namespace kagome::storage::trie {
     OUTCOME_TRY(node, getNode(nodes_->getRoot(), nibbles));
     if (node && node->getValue()) {
       OUTCOME_TRY(retrieveValue(const_cast<ValueAndHash &>(node->getValue())));
+      if(!node->getValue().value.has_value()) {
+        return TrieError::BROKEN_VALUE;
+      }
       return BufferView{*node->getValue().value};
     }
     return std::nullopt;

--- a/core/storage/trie/polkadot_trie/polkadot_trie_impl.cpp
+++ b/core/storage/trie/polkadot_trie/polkadot_trie_impl.cpp
@@ -490,9 +490,6 @@ namespace kagome::storage::trie {
     OUTCOME_TRY(node, getNode(nodes_->getRoot(), nibbles));
     if (node && node->getValue()) {
       OUTCOME_TRY(retrieveValue(const_cast<ValueAndHash &>(node->getValue())));
-      if(!node->getValue().value.has_value()) {
-        return TrieError::BROKEN_VALUE;
-      }
       return BufferView{*node->getValue().value};
     }
     return std::nullopt;
@@ -616,6 +613,9 @@ namespace kagome::storage::trie {
     if (value.hash && !value.value) {
       OUTCOME_TRY(loaded_value, nodes_->retrieve_value_(*value.hash));
       value.value = std::move(loaded_value);
+      if (!value.value) {
+        return TrieError::BROKEN_VALUE;
+      }
     }
     return outcome::success();
   }

--- a/core/storage/trie/polkadot_trie/trie_error.cpp
+++ b/core/storage/trie/polkadot_trie/trie_error.cpp
@@ -14,6 +14,9 @@ OUTCOME_CPP_DEFINE_CATEGORY(kagome::storage::trie, TrieError, e) {
     case TrieError::VALUE_RETRIEVE_NOT_PROVIDED:
       return "attempt to retrieve a value by hash with no corresponding "
              "callback provided";
+    case TrieError::BROKEN_VALUE:
+      return "value is absent from the database, although a node pointing to "
+             "this value exists";
   }
   return "unknown";
 }

--- a/core/storage/trie/polkadot_trie/trie_error.hpp
+++ b/core/storage/trie/polkadot_trie/trie_error.hpp
@@ -16,6 +16,8 @@ namespace kagome::storage::trie {
     NO_VALUE = 1,                 // no stored value found by the given key
     VALUE_RETRIEVE_NOT_PROVIDED,  // attempt to retrieve a value by hash with no
                                   // corresponding callback provided
+    BROKEN_VALUE,  // value is absent from the database, although a node
+                   // pointing to this value exists
   };
 }  // namespace kagome::storage::trie
 


### PR DESCRIPTION

[//]: # (
Copyright Quadrivium LLC
All Rights Reserved
SPDX-License-Identifier: Apache-2.0
)

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->

### Referenced issues

<!-- Id of the task from Jira. Example: Resolves #42 (Note that to link Pull Request with issue use one of the following keywords: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved). If there is no corresponding issue, then remove this field -->

### Description of the Change
This situation should not normally occur, so it was processed incorrectly in the code, leading to undefined behavior.
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
Kagome no longer crashes in this case.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs <!-- Optional -->
std::abort since this indicates that the database is corrupted.
<!-- Explain what other alternates were considered and why the proposed version was selected -->
