### PR TITLE
fix initial round

### DIFF
--- a/core/consensus/grandpa/impl/grandpa_impl.cpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.cpp
@@ -165,8 +165,8 @@ namespace kagome::consensus::grandpa {
              "Grandpa will be started with round #{}",
              round_state.round_number + 1);
 
-    auto authorities_res =
-        authority_manager_->authorities(round_state.last_finalized_block, true);
+    auto authorities_res = authority_manager_->authorities(
+        round_state.last_finalized_block, false);
     if (not authorities_res.has_value()) {
       logger_->critical(
           "Can't retrieve authorities for block {}. Stopping grandpa execution",


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- `initialRound` checks justification signatures, so must call `authorities(finalized=false)`; calling `authorities(finalized=true)` returned wrong set (for block with scheduled change) and caused "invalid signature"
  - reproduced on local network with short 10 block epoch/session, when restarting node, or after fast/warp sync

### Benefits

### Possible Drawbacks
