### PR TITLE
crypto version

### DIFF
--- a/cmake/Hunter/hunter-gate-url.cmake
+++ b/cmake/Hunter/hunter-gate-url.cmake
@@ -1,5 +1,5 @@
 HunterGate(
-  URL "https://github.com/qdrvm/hunter/archive/refs/tags/v0.23.257-qdrvm15.tar.gz"
-  SHA1 "7eede546a73aa8b5f637719439b9fb94f34e4094"
+  URL "https://github.com/qdrvm/hunter/archive/refs/tags/v0.23.257-qdrvm16.zip"
+  SHA1 "54888487402828e7e2d052322efde17d9b379a7b"
   LOCAL
 )

--- a/cmake/Hunter/hunter-gate-url.cmake
+++ b/cmake/Hunter/hunter-gate-url.cmake
@@ -1,5 +1,5 @@
 HunterGate(
-  URL "https://github.com/qdrvm/hunter/archive/refs/tags/v0.23.257-qdrvm16.zip"
-  SHA1 "54888487402828e7e2d052322efde17d9b379a7b"
+  URL "https://github.com/qdrvm/hunter/archive/refs/tags/v0.23.257-qdrvm17.zip"
+  SHA1 "bd1f5cb031899f06aee6f51b7e4df5ed3029e42e"
   LOCAL
 )

--- a/core/crypto/ecdsa/ecdsa_provider_impl.cpp
+++ b/core/crypto/ecdsa/ecdsa_provider_impl.cpp
@@ -95,16 +95,27 @@ namespace kagome::crypto {
   outcome::result<bool> EcdsaProviderImpl::verify(
       common::BufferView message,
       const EcdsaSignature &signature,
-      const EcdsaPublicKey &publicKey) const {
-    return verifyPrehashed(hasher_->blake2b_256(message), signature, publicKey);
+      const EcdsaPublicKey &publicKey,
+      bool allow_overflow) const {
+    return verifyPrehashed(
+        hasher_->blake2b_256(message), signature, publicKey, allow_overflow);
   }
 
   outcome::result<bool> EcdsaProviderImpl::verifyPrehashed(
       const EcdsaPrehashedMessage &message,
       const EcdsaSignature &signature,
       const EcdsaPublicKey &publicKey) const {
+    return verifyPrehashed(message, signature, publicKey, false);
+  }
+
+  outcome::result<bool> EcdsaProviderImpl::verifyPrehashed(
+      const EcdsaPrehashedMessage &message,
+      const EcdsaSignature &signature,
+      const EcdsaPublicKey &publicKey,
+      bool allow_overflow) const {
     OUTCOME_TRY(recovered,
-                recovery_.recoverPublickeyCompressed(signature, message));
+                recovery_.recoverPublickeyCompressed(
+                    signature, message, allow_overflow));
     return recovered == publicKey;
   }
 }  // namespace kagome::crypto

--- a/core/crypto/ecdsa/ecdsa_provider_impl.hpp
+++ b/core/crypto/ecdsa/ecdsa_provider_impl.hpp
@@ -37,10 +37,10 @@ namespace kagome::crypto {
         const EcdsaPrehashedMessage &message,
         const EcdsaPrivateKey &key) const override;
 
-    outcome::result<bool> verify(
-        common::BufferView message,
-        const EcdsaSignature &signature,
-        const EcdsaPublicKey &publicKey) const override;
+    outcome::result<bool> verify(common::BufferView message,
+                                 const EcdsaSignature &signature,
+                                 const EcdsaPublicKey &publicKey,
+                                 bool allow_overflow) const override;
 
     outcome::result<bool> verifyPrehashed(
         const EcdsaPrehashedMessage &message,
@@ -48,6 +48,11 @@ namespace kagome::crypto {
         const EcdsaPublicKey &publicKey) const override;
 
    private:
+    outcome::result<bool> verifyPrehashed(const EcdsaPrehashedMessage &message,
+                                          const EcdsaSignature &signature,
+                                          const EcdsaPublicKey &publicKey,
+                                          bool allow_overflow) const;
+
     std::unique_ptr<secp256k1_context, void (*)(secp256k1_context *)> context_;
     std::shared_ptr<Hasher> hasher_;
     log::Logger logger_;

--- a/core/crypto/ecdsa_provider.hpp
+++ b/core/crypto/ecdsa_provider.hpp
@@ -27,10 +27,10 @@ namespace kagome::crypto {
         const EcdsaPrehashedMessage &message,
         const EcdsaPrivateKey &key) const = 0;
 
-    virtual outcome::result<bool> verify(
-        common::BufferView message,
-        const EcdsaSignature &signature,
-        const EcdsaPublicKey &publicKey) const = 0;
+    virtual outcome::result<bool> verify(common::BufferView message,
+                                         const EcdsaSignature &signature,
+                                         const EcdsaPublicKey &publicKey,
+                                         bool allow_overflow) const = 0;
 
     virtual outcome::result<bool> verifyPrehashed(
         const EcdsaPrehashedMessage &message,

--- a/core/crypto/secp256k1/secp256k1_provider_impl.hpp
+++ b/core/crypto/secp256k1/secp256k1_provider_impl.hpp
@@ -27,18 +27,20 @@ namespace kagome::crypto {
     Secp256k1ProviderImpl();
 
     outcome::result<secp256k1::UncompressedPublicKey>
-    recoverPublickeyUncompressed(
-        const secp256k1::RSVSignature &signature,
-        const secp256k1::MessageHash &message_hash) const override;
+    recoverPublickeyUncompressed(const secp256k1::RSVSignature &signature,
+                                 const secp256k1::MessageHash &message_hash,
+                                 bool allow_overflow) const override;
 
     outcome::result<secp256k1::CompressedPublicKey> recoverPublickeyCompressed(
         const secp256k1::RSVSignature &signature,
-        const secp256k1::MessageHash &message_hash) const override;
+        const secp256k1::MessageHash &message_hash,
+        bool allow_overflow) const override;
 
    private:
     outcome::result<secp256k1_pubkey> recoverPublickey(
         const secp256k1::RSVSignature &signature,
-        const secp256k1::MessageHash &message_hash) const;
+        const secp256k1::MessageHash &message_hash,
+        bool allow_overflow) const;
 
     std::unique_ptr<secp256k1_context, void (*)(secp256k1_context *)> context_;
   };

--- a/core/crypto/secp256k1_provider.hpp
+++ b/core/crypto/secp256k1_provider.hpp
@@ -25,9 +25,9 @@ namespace kagome::crypto {
      * @return uncompressed public key or error
      */
     virtual outcome::result<secp256k1::UncompressedPublicKey>
-    recoverPublickeyUncompressed(
-        const secp256k1::RSVSignature &signature,
-        const secp256k1::MessageHash &message_hash) const = 0;
+    recoverPublickeyUncompressed(const secp256k1::RSVSignature &signature,
+                                 const secp256k1::MessageHash &message_hash,
+                                 bool allow_overflow) const = 0;
 
     /**
      * @brief recover public key in compressed form
@@ -36,9 +36,9 @@ namespace kagome::crypto {
      * @return compressed public key or error
      */
     virtual outcome::result<secp256k1::CompressedPublicKey>
-    recoverPublickeyCompressed(
-        const secp256k1::RSVSignature &signature,
-        const secp256k1::MessageHash &message_hash) const = 0;
+    recoverPublickeyCompressed(const secp256k1::RSVSignature &signature,
+                               const secp256k1::MessageHash &message_hash,
+                               bool allow_overflow) const = 0;
   };
 
 }  // namespace kagome::crypto

--- a/core/host_api/impl/crypto_extension.cpp
+++ b/core/host_api/impl/crypto_extension.cpp
@@ -439,14 +439,14 @@ namespace kagome::host_api {
       runtime::WasmPointer sig,
       runtime::WasmSpan msg,
       runtime::WasmPointer pub) {
-    return srVerify(true, sig, msg, pub);
+    return srVerify(/* deprecated= */ true, sig, msg, pub);
   }
 
   int32_t CryptoExtension::ext_crypto_sr25519_verify_version_2(
       runtime::WasmPointer sig,
       runtime::WasmSpan msg,
       runtime::WasmPointer pub) {
-    return srVerify(false, sig, msg, pub);
+    return srVerify(/* deprecated= */ false, sig, msg, pub);
   }
 
   namespace {
@@ -518,13 +518,13 @@ namespace kagome::host_api {
   runtime::WasmSpan
   CryptoExtension::ext_crypto_secp256k1_ecdsa_recover_version_1(
       runtime::WasmPointer sig, runtime::WasmPointer msg) {
-    return ecdsaRecover(true, sig, msg);
+    return ecdsaRecover(/* allow_overflow= */ true, sig, msg);
   }
 
   runtime::WasmSpan
   CryptoExtension::ext_crypto_secp256k1_ecdsa_recover_version_2(
       runtime::WasmPointer sig, runtime::WasmPointer msg) {
-    return ecdsaRecover(false, sig, msg);
+    return ecdsaRecover(/* allow_overflow= */ false, sig, msg);
   }
 
   runtime::WasmSpan CryptoExtension::ecdsaRecoverCompressed(
@@ -561,13 +561,13 @@ namespace kagome::host_api {
   runtime::WasmSpan
   CryptoExtension::ext_crypto_secp256k1_ecdsa_recover_compressed_version_1(
       runtime::WasmPointer sig, runtime::WasmPointer msg) {
-    return ecdsaRecoverCompressed(true, sig, msg);
+    return ecdsaRecoverCompressed(/* allow_overflow= */ true, sig, msg);
   }
 
   runtime::WasmSpan
   CryptoExtension::ext_crypto_secp256k1_ecdsa_recover_compressed_version_2(
       runtime::WasmPointer sig, runtime::WasmPointer msg) {
-    return ecdsaRecoverCompressed(false, sig, msg);
+    return ecdsaRecoverCompressed(/* allow_overflow= */ false, sig, msg);
   }
 
   runtime::WasmSpan CryptoExtension::ext_crypto_ecdsa_public_keys_version_1(
@@ -725,14 +725,14 @@ namespace kagome::host_api {
       runtime::WasmPointer sig,
       runtime::WasmSpan msg,
       runtime::WasmPointer pub) const {
-    return ecdsaVerify(true, sig, msg, pub);
+    return ecdsaVerify(/* allow_overflow= */ true, sig, msg, pub);
   }
 
   int32_t CryptoExtension::ext_crypto_ecdsa_verify_version_2(
       runtime::WasmPointer sig,
       runtime::WasmSpan msg,
       runtime::WasmPointer pub) const {
-    return ecdsaVerify(false, sig, msg, pub);
+    return ecdsaVerify(/* allow_overflow= */ false, sig, msg, pub);
   }
 
   int32_t CryptoExtension::ext_crypto_ecdsa_verify_prehashed_version_1(

--- a/core/host_api/impl/crypto_extension.hpp
+++ b/core/host_api/impl/crypto_extension.hpp
@@ -180,11 +180,15 @@ namespace kagome::host_api {
      */
     runtime::WasmSpan ext_crypto_secp256k1_ecdsa_recover_version_1(
         runtime::WasmPointer sig, runtime::WasmPointer msg);
+    runtime::WasmSpan ext_crypto_secp256k1_ecdsa_recover_version_2(
+        runtime::WasmPointer sig, runtime::WasmPointer msg);
 
     /**
      * @see HostApi::ext_crypto_secp256k1_ecdsa_recover_compressed_version_1
      */
     runtime::WasmSpan ext_crypto_secp256k1_ecdsa_recover_compressed_version_1(
+        runtime::WasmPointer sig, runtime::WasmPointer msg);
+    runtime::WasmSpan ext_crypto_secp256k1_ecdsa_recover_compressed_version_2(
         runtime::WasmPointer sig, runtime::WasmPointer msg);
 
     /**
@@ -241,6 +245,21 @@ namespace kagome::host_api {
     runtime::Memory &getMemory() const {
       return memory_provider_->getCurrentMemory()->get();
     }
+
+    int32_t srVerify(bool deprecated,
+                     runtime::WasmPointer sig,
+                     runtime::WasmSpan msg,
+                     runtime::WasmPointer pub);
+    int32_t ecdsaVerify(bool allow_overflow,
+                        runtime::WasmPointer sig,
+                        runtime::WasmSpan msg,
+                        runtime::WasmPointer key) const;
+    runtime::WasmSpan ecdsaRecover(bool allow_overflow,
+                                   runtime::WasmPointer sig,
+                                   runtime::WasmPointer msg);
+    runtime::WasmSpan ecdsaRecoverCompressed(bool allow_overflow,
+                                             runtime::WasmPointer sig,
+                                             runtime::WasmPointer msg);
 
     std::shared_ptr<const runtime::MemoryProvider> memory_provider_;
     std::shared_ptr<const crypto::Sr25519Provider> sr25519_provider_;

--- a/core/host_api/impl/host_api_impl.cpp
+++ b/core/host_api/impl/host_api_impl.cpp
@@ -367,7 +367,7 @@ namespace kagome::host_api {
 
   runtime::WasmSpan HostApiImpl::ext_crypto_secp256k1_ecdsa_recover_version_2(
       runtime::WasmPointer sig, runtime::WasmPointer msg) {
-    return crypto_ext_.ext_crypto_secp256k1_ecdsa_recover_version_1(sig, msg);
+    return crypto_ext_.ext_crypto_secp256k1_ecdsa_recover_version_2(sig, msg);
   }
 
   runtime::WasmSpan
@@ -380,7 +380,7 @@ namespace kagome::host_api {
   runtime::WasmSpan
   HostApiImpl::ext_crypto_secp256k1_ecdsa_recover_compressed_version_2(
       runtime::WasmPointer sig, runtime::WasmPointer msg) {
-    return crypto_ext_.ext_crypto_secp256k1_ecdsa_recover_compressed_version_1(
+    return crypto_ext_.ext_crypto_secp256k1_ecdsa_recover_compressed_version_2(
         sig, msg);
   }
 

--- a/test/core/crypto/ecdsa/ecdsa_provider_test.cpp
+++ b/test/core/crypto/ecdsa/ecdsa_provider_test.cpp
@@ -77,7 +77,7 @@ TEST_F(EcdsaProviderTest, SignVerifySuccess) {
                       ecdsa_provider_->sign(message, key_pair.secret_key));
   EXPECT_OUTCOME_TRUE(
       verify_res,
-      ecdsa_provider_->verify(message, signature, key_pair.public_key));
+      ecdsa_provider_->verify(message, signature, key_pair.public_key, false));
   ASSERT_EQ(verify_res, true);
 }
 
@@ -95,7 +95,8 @@ TEST_F(EcdsaProviderTest, VerifyWrongKeyFail) {
   auto another_keypair = generate();
   EXPECT_OUTCOME_TRUE(
       ver_res,
-      ecdsa_provider_->verify(message, signature, another_keypair.public_key));
+      ecdsa_provider_->verify(
+          message, signature, another_keypair.public_key, false));
 
   ASSERT_FALSE(ver_res);
 }
@@ -133,5 +134,5 @@ TEST_F(EcdsaProviderTest, Compatible) {
           "3dde91174bd9359027be59a428b8146513df80a2a3c7eda2194f64de04a69ab97b75"
           "3169e94db6ffd50921a2668a48b94ca11e3d32c1ff19cfe88890aa7e8f3c00")
           .value();
-  EXPECT_TRUE(ecdsa_provider_->verify({}, sig, keys.public_key).value());
+  EXPECT_TRUE(ecdsa_provider_->verify({}, sig, keys.public_key, false).value());
 }

--- a/test/core/crypto/secp256k1/secp256k1_provider_test.cpp
+++ b/test/core/crypto/secp256k1/secp256k1_provider_test.cpp
@@ -78,7 +78,7 @@ TEST_F(Secp256k1ProviderTest, RecoverInvalidRecidFailure) {
   *wrong_signature.rbegin() = 0xFF;
   EXPECT_OUTCOME_ERROR(res,
                        secp256K1_provider->recoverPublickeyUncompressed(
-                           wrong_signature, secp_message_hash),
+                           wrong_signature, secp_message_hash, false),
                        Secp256k1ProviderError::INVALID_V_VALUE);
 }
 
@@ -92,7 +92,7 @@ TEST_F(Secp256k1ProviderTest, RecoverInvalidSignatureFailure) {
   RSVSignature wrong_signature = secp_signature;
   *(wrong_signature.begin() + 3) = 0xFF;
   auto res = secp256K1_provider->recoverPublickeyUncompressed(
-      wrong_signature, secp_message_hash);
+      wrong_signature, secp_message_hash, false);
   // corrupted signature may recover some public key, but this key is wrong
   if (res) {
     ASSERT_NE(res.value(), secp_public_key_expanded);
@@ -110,7 +110,7 @@ TEST_F(Secp256k1ProviderTest, RecoverInvalidSignatureFailure) {
 TEST_F(Secp256k1ProviderTest, RecoverUncompressedSuccess) {
   EXPECT_OUTCOME_TRUE(public_key,
                       secp256K1_provider->recoverPublickeyUncompressed(
-                          secp_signature, secp_message_hash));
+                          secp_signature, secp_message_hash, false));
   EXPECT_EQ(public_key, secp_public_key_expanded);
 }
 
@@ -122,6 +122,6 @@ TEST_F(Secp256k1ProviderTest, RecoverUncompressedSuccess) {
 TEST_F(Secp256k1ProviderTest, RecoverCompressedSuccess) {
   EXPECT_OUTCOME_TRUE(public_key,
                       secp256K1_provider->recoverPublickeyCompressed(
-                          secp_signature, secp_message_hash));
+                          secp_signature, secp_message_hash, false));
   EXPECT_EQ(public_key, secp_public_key_compressed);
 }


### PR DESCRIPTION
### Referenced issues
- https://github.com/qdrvm/KAGOME-audit/issues/18

### Description of the Change
- sr25519 v1 `verify_deprecated` and v2 `verify`.
- ecdsa v1 `allow_overflow=true` and v2 `allow_overflow=true` (libsecp256k1 patch).

### Benefits

### Possible Drawbacks