### PR TITLE
load blocks deduplicate

### DIFF
--- a/core/network/impl/synchronizer_impl.hpp
+++ b/core/network/impl/synchronizer_impl.hpp
@@ -18,6 +18,7 @@
 #include "application/app_state_manager.hpp"
 #include "consensus/timeline/block_executor.hpp"
 #include "consensus/timeline/block_header_appender.hpp"
+#include "injector/lazy.hpp"
 #include "metrics/metrics.hpp"
 #include "network/impl/state_sync_request_flow.hpp"
 #include "network/router.hpp"
@@ -103,6 +104,7 @@ namespace kagome::network {
         std::shared_ptr<libp2p::basic::Scheduler> scheduler,
         std::shared_ptr<crypto::Hasher> hasher,
         primitives::events::ChainSubscriptionEnginePtr chain_sub_engine,
+        LazySPtr<consensus::Timeline> timeline,
         std::shared_ptr<IBeefy> beefy,
         std::shared_ptr<consensus::grandpa::Environment> grandpa_environment,
         WeakIoContext main_thread);
@@ -226,6 +228,7 @@ namespace kagome::network {
     std::shared_ptr<PeerManager> peer_manager_;
     std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
     std::shared_ptr<crypto::Hasher> hasher_;
+    LazySPtr<consensus::Timeline> timeline_;
     std::shared_ptr<IBeefy> beefy_;
     std::shared_ptr<consensus::grandpa::Environment> grandpa_environment_;
     primitives::events::ChainSubscriptionEnginePtr chain_sub_engine_;
@@ -281,6 +284,8 @@ namespace kagome::network {
     std::atomic_bool asking_blocks_portion_in_progress_ = false;
     std::set<libp2p::peer::PeerId> busy_peers_;
     std::unordered_set<primitives::BlockInfo> load_blocks_;
+    std::pair<primitives::BlockNumber, std::chrono::milliseconds>
+        load_blocks_max_{};
 
     std::map<std::tuple<libp2p::peer::PeerId, BlocksRequest::Fingerprint>,
              const char *>

--- a/core/network/impl/synchronizer_impl.hpp
+++ b/core/network/impl/synchronizer_impl.hpp
@@ -11,6 +11,7 @@
 #include <atomic>
 #include <mutex>
 #include <queue>
+#include <unordered_set>
 
 #include <libp2p/basic/scheduler.hpp>
 
@@ -273,6 +274,7 @@ namespace kagome::network {
     std::atomic_bool applying_in_progress_ = false;
     std::atomic_bool asking_blocks_portion_in_progress_ = false;
     std::set<libp2p::peer::PeerId> busy_peers_;
+    std::unordered_set<primitives::BlockInfo> load_blocks_;
 
     std::map<std::tuple<libp2p::peer::PeerId, BlocksRequest::Fingerprint>,
              const char *>

--- a/test/core/network/synchronizer_test.cpp
+++ b/test/core/network/synchronizer_test.cpp
@@ -28,6 +28,7 @@
 #include "mock/core/storage/trie_pruner/trie_pruner_mock.hpp"
 #include "network/impl/synchronizer_impl.hpp"
 #include "primitives/common.hpp"
+#include "testutil/lazy.hpp"
 #include "testutil/literals.hpp"
 #include "testutil/prepare_loggers.hpp"
 
@@ -40,6 +41,7 @@ using namespace consensus::grandpa;
 using namespace storage;
 
 using std::chrono_literals::operator""ms;
+using kagome::consensus::Timeline;
 using network::Synchronizer;
 using primitives::BlockData;
 using primitives::BlockHash;
@@ -84,6 +86,7 @@ class SynchronizerTest
     auto state_pruner =
         std::make_shared<kagome::storage::trie_pruner::TriePrunerMock>();
 
+    auto _timeline = testutil::sptr_to_lazy<Timeline>(timeline);
     synchronizer =
         std::make_shared<network::SynchronizerImpl>(app_config,
                                                     app_state_manager,
@@ -98,6 +101,7 @@ class SynchronizerTest
                                                     scheduler,
                                                     hasher,
                                                     chain_sub_engine,
+                                                    _timeline,
                                                     nullptr,
                                                     grandpa_environment,
                                                     WeakIoContext{});
@@ -126,6 +130,7 @@ class SynchronizerTest
       std::make_shared<crypto::HasherMock>();
   primitives::events::ChainSubscriptionEnginePtr chain_sub_engine =
       std::make_shared<primitives::events::ChainSubscriptionEngine>();
+  std::shared_ptr<Timeline> timeline;
   std::shared_ptr<BufferStorageMock> buffer_storage =
       std::make_shared<BufferStorageMock>();
   std::shared_ptr<EnvironmentMock> grandpa_environment =


### PR DESCRIPTION
### Referenced issues
- #1890

### Description of the Change
- deduplicate `loadBlocks` for same block
- remember max requested block, expires in 5 seconds

### Benefits

### Possible Drawbacks
- handshake/announce (`syncByBlockInfo`/`syncByBlockHeader`) does not check `busy_peers_`