### PR TITLE
clear prefix

### DIFF
--- a/core/storage/trie/impl/topper_trie_batch_impl.cpp
+++ b/core/storage/trie/impl/topper_trie_batch_impl.cpp
@@ -125,7 +125,7 @@ namespace kagome::storage::trie {
 
     cleared_prefixes_.emplace_back(prefix);
     if (parent_.lock() != nullptr) {
-      return outcome::success(std::make_tuple(true, 0ULL));
+      return outcome::success(std::make_tuple(false, 0ULL));
     }
     return Error::PARENT_EXPIRED;
   }


### PR DESCRIPTION
### Referenced issues

### Description of the Change
```rust
pub enum KillStorageResult {
  AllRemoved(u32), // == 0 == false
  SomeRemaining(u32), // == 1 == true
}

impl KillStorageResult {
  fn from(r: MultiRemovalResults) -> KillStorageResult {
    match r.maybe_cursor {
      None => Self::AllRemoved(r.loops),
    }
  }
}

impl BasicExternalities {
  fn clear_prefix() -> MultiRemovalResults {
    MultiRemovalResults { maybe_cursor: None }
  }
}
```

### Benefits

### Possible Drawbacks