### PR TITLE
fix signals

### DIFF
--- a/core/application/impl/app_state_manager_impl.hpp
+++ b/core/application/impl/app_state_manager_impl.hpp
@@ -49,6 +49,9 @@ namespace kagome::application {
     void doShutdown() override;
 
    private:
+    static std::atomic_bool signals_enabled;
+    static void signalsEnable();
+    static void signalsDisable();
     static std::weak_ptr<AppStateManagerImpl> wp_to_myself;
     static void shuttingDownSignalsHandler(int);
 


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- unsubscribe signals on signal/destructor/shutdown
  - after pressing ctrl+c first time shutdown may be long or hang, so pressing ctrl+c second time must terminate

### Benefits

### Possible Drawbacks