### PR TITLE
fix move, refactor grandpa

### DIFF
--- a/core/consensus/grandpa/catch_up_observer.hpp
+++ b/core/consensus/grandpa/catch_up_observer.hpp
@@ -34,10 +34,8 @@ namespace kagome::consensus::grandpa {
      * Handler of grandpa catch-up-response messages
      * @param msg catch-up-response messages
      */
-    virtual void onCatchUpResponse(
-        std::optional<std::shared_ptr<GrandpaContext>> &&existed_context,
-        const libp2p::peer::PeerId &peer_id,
-        const network::CatchUpResponse &msg) = 0;
+    virtual void onCatchUpResponse(const libp2p::peer::PeerId &peer_id,
+                                   network::CatchUpResponse &&msg) = 0;
   };
 
 }  // namespace kagome::consensus::grandpa

--- a/core/consensus/grandpa/grandpa_context.hpp
+++ b/core/consensus/grandpa/grandpa_context.hpp
@@ -15,25 +15,14 @@
 #include <set>
 
 namespace kagome::consensus::grandpa {
+  using MissingBlocks =
+      std::set<primitives::BlockInfo, std::greater<primitives::BlockInfo>>;
 
   struct GrandpaContext final {
-    // Payload
-    std::optional<libp2p::peer::PeerId> peer_id{};
-    std::optional<network::VoteMessage> vote{};
-    std::optional<network::CatchUpResponse> catch_up_response{};
-    std::optional<network::FullCommitMessage> commit{};
-    std::set<primitives::BlockInfo, std::greater<primitives::BlockInfo>>
-        missing_blocks{};
+    MissingBlocks missing_blocks{};
     size_t checked_signature_counter = 0;
     size_t invalid_signature_counter = 0;
     size_t unknown_voter_counter = 0;
-
-    GrandpaContext() = default;
-    GrandpaContext(const GrandpaContext &) = default;
-    GrandpaContext(GrandpaContext &&) = default;
-
-    GrandpaContext &operator=(const GrandpaContext &) = default;
-    GrandpaContext &operator=(GrandpaContext &&) = default;
   };
 
 }  // namespace kagome::consensus::grandpa

--- a/core/consensus/grandpa/impl/voting_round_impl.cpp
+++ b/core/consensus/grandpa/impl/voting_round_impl.cpp
@@ -154,8 +154,7 @@ namespace kagome::consensus::grandpa {
     last_finalized_block_ = round_state.last_finalized_block;
 
     if (round_number_ != 0) {
-      std::optional<GrandpaContext> ctx;
-      VotingRoundUpdate update{*this, ctx};
+      VotingRoundUpdate update{*this};
       for (auto &vote : round_state.votes) {
         update.vote(vote);
       }
@@ -498,8 +497,7 @@ namespace kagome::consensus::grandpa {
       return;
     }
     const auto &signed_primary_proposal = signed_primary_proposal_opt.value();
-    std::optional<GrandpaContext> ctx;
-    onProposal(ctx, signed_primary_proposal, Propagation::NEEDLESS);
+    onProposal({}, signed_primary_proposal, Propagation::NEEDLESS);
     env_->onVoted(round_number_, voter_set_->id(), signed_primary_proposal);
   }
 
@@ -557,8 +555,7 @@ namespace kagome::consensus::grandpa {
       return;
     }
     auto &signed_prevote = signed_prevote_opt.value();
-    std::optional<GrandpaContext> ctx;
-    if (onPrevote(ctx, signed_prevote, Propagation::NEEDLESS)) {
+    if (onPrevote({}, signed_prevote, Propagation::NEEDLESS)) {
       update(false, true, false);
       if (save_cached_votes_) {
         save_cached_votes_();
@@ -614,8 +611,7 @@ namespace kagome::consensus::grandpa {
       return;
     }
     auto &signed_precommit = signed_precommit_opt.value();
-    std::optional<GrandpaContext> ctx;
-    if (onPrecommit(ctx, signed_precommit, Propagation::NEEDLESS)) {
+    if (onPrecommit({}, signed_precommit, Propagation::NEEDLESS)) {
       update(false, false, true);
       if (save_cached_votes_) {
         save_cached_votes_();
@@ -683,8 +679,7 @@ namespace kagome::consensus::grandpa {
              round_number_,
              justification.block_info);
 
-    std::optional<GrandpaContext> ctx;
-    VotingRoundUpdate update{*this, ctx};
+    VotingRoundUpdate update{*this};
     for (auto &vote : justification.items) {
       update.vote(vote);
     }
@@ -853,10 +848,9 @@ namespace kagome::consensus::grandpa {
     return voter_set_->id();
   }
 
-  void VotingRoundImpl::onProposal(
-      std::optional<GrandpaContext> &grandpa_context,
-      const SignedMessage &proposal,
-      Propagation propagation) {
+  void VotingRoundImpl::onProposal(OptRef<GrandpaContext> grandpa_context,
+                                   const SignedMessage &proposal,
+                                   Propagation propagation) {
     if (not isPrimary(proposal.id)) {
       logger_->warn(
           "Round #{}: Proposal signed by {} was rejected: "
@@ -917,10 +911,9 @@ namespace kagome::consensus::grandpa {
     }
   }
 
-  bool VotingRoundImpl::onPrevote(
-      std::optional<GrandpaContext> &grandpa_context,
-      const SignedMessage &prevote,
-      Propagation propagation) {
+  bool VotingRoundImpl::onPrevote(OptRef<GrandpaContext> grandpa_context,
+                                  const SignedMessage &prevote,
+                                  Propagation propagation) {
     if (grandpa_context) {
       grandpa_context->checked_signature_counter++;
     }
@@ -992,10 +985,9 @@ namespace kagome::consensus::grandpa {
     return true;
   }
 
-  bool VotingRoundImpl::onPrecommit(
-      std::optional<GrandpaContext> &grandpa_context,
-      const SignedMessage &precommit,
-      Propagation propagation) {
+  bool VotingRoundImpl::onPrecommit(OptRef<GrandpaContext> grandpa_context,
+                                    const SignedMessage &precommit,
+                                    Propagation propagation) {
     if (grandpa_context) {
       grandpa_context->checked_signature_counter++;
     }
@@ -1123,8 +1115,7 @@ namespace kagome::consensus::grandpa {
 
   template <typename T>
   outcome::result<void> VotingRoundImpl::onSigned(
-      std::optional<GrandpaContext> &grandpa_context,
-      const SignedMessage &vote) {
+      OptRef<GrandpaContext> grandpa_context, const SignedMessage &vote) {
     BOOST_ASSERT(vote.is<T>());
 
     // Check if voter is contained in current voter set
@@ -1206,12 +1197,10 @@ namespace kagome::consensus::grandpa {
   }
 
   template outcome::result<void> VotingRoundImpl::onSigned<Prevote>(
-      std::optional<GrandpaContext> &grandpa_context,
-      const SignedMessage &vote);
+      OptRef<GrandpaContext> grandpa_context, const SignedMessage &vote);
 
   template outcome::result<void> VotingRoundImpl::onSigned<Precommit>(
-      std::optional<GrandpaContext> &grandpa_context,
-      const SignedMessage &vote);
+      OptRef<GrandpaContext> grandpa_context, const SignedMessage &vote);
 
   bool VotingRoundImpl::updateGrandpaGhost() {
     if (prevotes_->getTotalWeight() < threshold_) {

--- a/core/consensus/grandpa/impl/voting_round_impl.hpp
+++ b/core/consensus/grandpa/impl/voting_round_impl.hpp
@@ -131,7 +131,7 @@ namespace kagome::consensus::grandpa {
      * Basically method just checks if received propose was produced by the
      * primary and if so, it is stored in primary_vote_ field
      */
-    void onProposal(std::optional<GrandpaContext> &grandpa_context,
+    void onProposal(OptRef<GrandpaContext> grandpa_context,
                     const SignedMessage &proposal,
                     Propagation propagation) override;
 
@@ -142,7 +142,7 @@ namespace kagome::consensus::grandpa {
      * state (\see update)
      * @returns true if inner state has changed
      */
-    bool onPrevote(std::optional<GrandpaContext> &grandpa_context,
+    bool onPrevote(OptRef<GrandpaContext> grandpa_context,
                    const SignedMessage &prevote,
                    Propagation propagation) override;
 
@@ -152,7 +152,7 @@ namespace kagome::consensus::grandpa {
      * Then we try to update round state and finalize
      * @returns true if inner state has changed
      */
-    bool onPrecommit(std::optional<GrandpaContext> &grandpa_context,
+    bool onPrecommit(OptRef<GrandpaContext> grandpa_context,
                      const SignedMessage &precommit,
                      Propagation propagation) override;
 
@@ -259,9 +259,8 @@ namespace kagome::consensus::grandpa {
 
     /// Triggered when we receive {@param vote} for the current peer
     template <typename T>
-    outcome::result<void> onSigned(
-        std::optional<GrandpaContext> &grandpa_context,
-        const SignedMessage &vote);
+    outcome::result<void> onSigned(OptRef<GrandpaContext> grandpa_context,
+                                   const SignedMessage &vote);
 
     /**
      * Invoked during each onSingedPrevote.

--- a/core/consensus/grandpa/round_observer.hpp
+++ b/core/consensus/grandpa/round_observer.hpp
@@ -36,20 +36,17 @@ namespace kagome::consensus::grandpa {
      * @param msg vote message
      */
     virtual void onVoteMessage(
-        std::optional<std::shared_ptr<GrandpaContext>> &&existed_context,
         const libp2p::peer::PeerId &peer_id,
         std::optional<network::PeerStateCompact> &&info_opt,
-        const VoteMessage &msg) = 0;
+        VoteMessage &&msg) = 0;
 
     /**
      * Handler of grandpa finalization messages
      * @param peer_id finalization sender
      * @param f finalization message
      */
-    virtual void onCommitMessage(
-        std::optional<std::shared_ptr<GrandpaContext>> &&existed_context,
-        const libp2p::peer::PeerId &peer_id,
-        const network::FullCommitMessage &msg) = 0;
+    virtual void onCommitMessage(const libp2p::peer::PeerId &peer_id,
+                                 network::FullCommitMessage &&msg) = 0;
   };
 
 }  // namespace kagome::consensus::grandpa

--- a/core/consensus/grandpa/voting_round.hpp
+++ b/core/consensus/grandpa/voting_round.hpp
@@ -9,6 +9,7 @@
 #include "common/tagged.hpp"
 #include "consensus/grandpa/movable_round_state.hpp"
 #include "consensus/grandpa/round_observer.hpp"
+#include "utils/optref.hpp"
 
 namespace kagome::consensus::grandpa {
 
@@ -75,15 +76,15 @@ namespace kagome::consensus::grandpa {
 
     enum class Propagation : bool { NEEDLESS = false, REQUESTED = true };
 
-    virtual void onProposal(std::optional<GrandpaContext> &grandpa_context,
+    virtual void onProposal(OptRef<GrandpaContext> grandpa_context,
                             const SignedMessage &primary_propose,
                             Propagation propagation) = 0;
 
-    virtual bool onPrevote(std::optional<GrandpaContext> &grandpa_context,
+    virtual bool onPrevote(OptRef<GrandpaContext> grandpa_context,
                            const SignedMessage &prevote,
                            Propagation propagation) = 0;
 
-    virtual bool onPrecommit(std::optional<GrandpaContext> &grandpa_context,
+    virtual bool onPrecommit(OptRef<GrandpaContext> grandpa_context,
                              const SignedMessage &precommit,
                              Propagation propagation) = 0;
 

--- a/core/consensus/grandpa/voting_round_update.hpp
+++ b/core/consensus/grandpa/voting_round_update.hpp
@@ -15,7 +15,7 @@ namespace kagome::consensus::grandpa {
    */
   struct VotingRoundUpdate {
     VotingRound &round;
-    std::optional<GrandpaContext> ctx;
+    OptRef<GrandpaContext> ctx{};
     bool propagate = false;
     bool update_prevote = false;
     bool update_precommit = false;

--- a/core/network/impl/protocols/grandpa_protocol.cpp
+++ b/core/network/impl/protocols/grandpa_protocol.cpp
@@ -109,14 +109,14 @@ namespace kagome::network {
               base_.logger(), "VoteMessage has received from {}", peer_id);
           auto info = peer_manager_->getPeerState(peer_id);
           grandpa_observer_->onVoteMessage(
-              std::nullopt, peer_id, compactFromRefToOwn(info), vote_message);
+              peer_id, compactFromRefToOwn(info), std::move(vote_message));
           addKnown(peer_id, hash);
         },
         [&](FullCommitMessage &&commit_message) {
           SL_VERBOSE(
               base_.logger(), "CommitMessage has received from {}", peer_id);
-          grandpa_observer_->onCommitMessage(
-              std::nullopt, peer_id, commit_message);
+          grandpa_observer_->onCommitMessage(peer_id,
+                                             std::move(commit_message));
           addKnown(peer_id, hash);
         },
         [&](GrandpaNeighborMessage &&neighbor_message) {
@@ -140,8 +140,8 @@ namespace kagome::network {
         [&](network::CatchUpResponse &&catch_up_response) {
           SL_VERBOSE(
               base_.logger(), "CatchUpResponse has received from {}", peer_id);
-          grandpa_observer_->onCatchUpResponse(
-              std::nullopt, peer_id, catch_up_response);
+          grandpa_observer_->onCatchUpResponse(peer_id,
+                                               std::move(catch_up_response));
         });
   }
 

--- a/core/utils/optref.hpp
+++ b/core/utils/optref.hpp
@@ -1,0 +1,12 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+namespace kagome {
+  template <typename T>
+  using OptRef = T *;
+}  // namespace kagome

--- a/test/core/consensus/grandpa/voting_round/voting_round_test.cpp
+++ b/test/core/consensus/grandpa/voting_round/voting_round_test.cpp
@@ -278,15 +278,14 @@ TEST_F(VotingRoundTest, EstimateIsValid) {
   // when 1.
   // Alice prevotes
   auto alice_vote = preparePrevote(kAlice, kAliceSignature, Prevote{9, "FC"_H});
-  std::optional<GrandpaContext> empty_context{};
-  round_->onPrevote(empty_context, alice_vote, Propagation::NEEDLESS);
+  round_->onPrevote({}, alice_vote, Propagation::NEEDLESS);
   round_->update(VotingRound::IsPreviousRoundChanged{false},
                  VotingRound::IsPrevotesChanged{true},
                  VotingRound::IsPrecommitsChanged{false});
 
   // Bob prevotes
   auto bob_vote = preparePrevote(kBob, kBobSignature, Prevote{9, "ED"_H});
-  round_->onPrevote(empty_context, bob_vote, Propagation::NEEDLESS);
+  round_->onPrevote({}, bob_vote, Propagation::NEEDLESS);
   round_->update(VotingRound::IsPreviousRoundChanged{false},
                  VotingRound::IsPrevotesChanged{true},
                  VotingRound::IsPrecommitsChanged{false});
@@ -299,7 +298,7 @@ TEST_F(VotingRoundTest, EstimateIsValid) {
   // Eve prevotes
   auto eve_vote = preparePrevote(kEve, kEveSignature, Prevote{6, "F"_H});
 
-  round_->onPrevote(empty_context, eve_vote, Propagation::NEEDLESS);
+  round_->onPrevote({}, eve_vote, Propagation::NEEDLESS);
   round_->update(VotingRound::IsPreviousRoundChanged{false},
                  VotingRound::IsPrevotesChanged{true},
                  VotingRound::IsPrecommitsChanged{false});
@@ -309,17 +308,16 @@ TEST_F(VotingRoundTest, EstimateIsValid) {
 }
 
 TEST_F(VotingRoundTest, EquivocateDoesNotDoubleCount) {
-  std::optional<GrandpaContext> empty_context{};
   auto alice1 = preparePrevote(kAlice, kAliceSignature, Prevote{9, "FC"_H});
-  round_->onPrevote(empty_context, alice1, Propagation::NEEDLESS);
+  round_->onPrevote({}, alice1, Propagation::NEEDLESS);
   auto alice2 = preparePrevote(kAlice, kAliceSignature, Prevote{9, "ED"_H});
-  round_->onPrevote(empty_context, alice2, Propagation::NEEDLESS);
+  round_->onPrevote({}, alice2, Propagation::NEEDLESS);
   auto alice3 = preparePrevote(kAlice, kAliceSignature, Prevote{6, "F"_H});
-  round_->onPrevote(empty_context, alice3, Propagation::NEEDLESS);
+  round_->onPrevote({}, alice3, Propagation::NEEDLESS);
   round_->update(false, true, false);
   ASSERT_EQ(round_->prevoteGhost(), std::nullopt);
   auto bob = preparePrevote(kBob, kBobSignature, Prevote{7, "FA"_H});
-  round_->onPrevote(empty_context, bob, Propagation::NEEDLESS);
+  round_->onPrevote({}, bob, Propagation::NEEDLESS);
   round_->update(false, true, false);
   ASSERT_EQ(round_->prevoteGhost(), (BlockInfo{7, "FA"_H}));
 }
@@ -356,8 +354,7 @@ TEST_F(VotingRoundTest, Finalization) {
   // when 1.
   // Alice Prevotes FC
   auto alice_prevote = preparePrevote(kAlice, kAliceSignature, {9, "FC"_H});
-  std::optional<GrandpaContext> empty_context{};
-  round_->onPrevote(empty_context, alice_prevote, Propagation::NEEDLESS);
+  round_->onPrevote({}, alice_prevote, Propagation::NEEDLESS);
   round_->update(VotingRound::IsPreviousRoundChanged{false},
                  VotingRound::IsPrevotesChanged{true},
                  VotingRound::IsPrecommitsChanged{false});
@@ -365,7 +362,7 @@ TEST_F(VotingRoundTest, Finalization) {
   // when 2.
   // Bob prevotes ED
   auto bob_prevote = preparePrevote(kBob, kBobSignature, {9, "ED"_H});
-  round_->onPrevote(empty_context, bob_prevote, Propagation::NEEDLESS);
+  round_->onPrevote({}, bob_prevote, Propagation::NEEDLESS);
   round_->update(VotingRound::IsPreviousRoundChanged{false},
                  VotingRound::IsPrevotesChanged{true},
                  VotingRound::IsPrecommitsChanged{false});
@@ -378,7 +375,7 @@ TEST_F(VotingRoundTest, Finalization) {
   // when 3.
   // Alice precommits FC
   auto alice_precommit = preparePrecommit(kAlice, kAliceSignature, {9, "FC"_H});
-  round_->onPrecommit(empty_context, alice_precommit, Propagation::NEEDLESS);
+  round_->onPrecommit({}, alice_precommit, Propagation::NEEDLESS);
   round_->update(VotingRound::IsPreviousRoundChanged{false},
                  VotingRound::IsPrevotesChanged{false},
                  VotingRound::IsPrecommitsChanged{true});
@@ -386,7 +383,7 @@ TEST_F(VotingRoundTest, Finalization) {
   // when 4.
   // Bob precommits ED
   auto bob_precommit = preparePrecommit(kBob, kBobSignature, {9, "ED"_H});
-  round_->onPrecommit(empty_context, bob_precommit, Propagation::NEEDLESS);
+  round_->onPrecommit({}, bob_precommit, Propagation::NEEDLESS);
   round_->update(VotingRound::IsPreviousRoundChanged{false},
                  VotingRound::IsPrevotesChanged{false},
                  VotingRound::IsPrecommitsChanged{true});
@@ -396,7 +393,7 @@ TEST_F(VotingRoundTest, Finalization) {
 
   // when 5.
   // Eve prevotes
-  round_->onPrevote(empty_context,
+  round_->onPrevote({},
                     preparePrevote(kEve, kEveSignature, {6, "EA"_H}),
                     Propagation::NEEDLESS);
   round_->update(VotingRound::IsPreviousRoundChanged{false},
@@ -407,7 +404,7 @@ TEST_F(VotingRoundTest, Finalization) {
 
   // when 6.
   // Eve precommits
-  round_->onPrecommit(empty_context,
+  round_->onPrecommit({},
                       preparePrecommit(kEve, kEveSignature, {6, "EA"_H}),
                       Propagation::NEEDLESS);
   round_->update(VotingRound::IsPreviousRoundChanged{false},
@@ -420,8 +417,7 @@ TEST_F(VotingRoundTest, Finalization) {
 
 ACTION_P(onProposed, test_fixture) {
   // imitating primary proposed is received from network
-  std::optional<GrandpaContext> empty{};
-  test_fixture->round_->onProposal(empty, arg2, Propagation::NEEDLESS);
+  test_fixture->round_->onProposal({}, arg2, Propagation::NEEDLESS);
 }
 
 ACTION_P(onPrevoted, test_fixture) {
@@ -429,18 +425,17 @@ ACTION_P(onPrevoted, test_fixture) {
   auto signed_prevote = arg2;
 
   // send Alice's prevote
-  std::optional<GrandpaContext> empty{};
-  test_fixture->round_->onPrevote(empty, signed_prevote, Propagation::NEEDLESS);
+  test_fixture->round_->onPrevote({}, signed_prevote, Propagation::NEEDLESS);
   // send Bob's prevote
   test_fixture->round_->onPrevote(
-      empty,
+      {},
       SignedMessage{.message = signed_prevote.message,
                     .signature = test_fixture->kBobSignature,
                     .id = test_fixture->kBob},
       Propagation::NEEDLESS);
   // send Eve's prevote
   test_fixture->round_->onPrevote(
-      empty,
+      {},
       SignedMessage{.message = signed_prevote.message,
                     .signature = test_fixture->kEveSignature,
                     .id = test_fixture->kEve},
@@ -453,14 +448,13 @@ ACTION_P(onPrevoted, test_fixture) {
 ACTION_P(onPrecommitted, test_fixture) {
   // imitate receiving precommit from other peers
   auto signed_precommit = arg2;
-  std::optional<GrandpaContext> empty{};
 
   // send Alice's precommit
   test_fixture->round_->onPrecommit(
-      empty, signed_precommit, Propagation::NEEDLESS);
+      {}, signed_precommit, Propagation::NEEDLESS);
   // send Bob's precommit
   test_fixture->round_->onPrecommit(
-      empty,
+      {},
       SignedMessage{.message = signed_precommit.message,
                     .signature = test_fixture->kBobSignature,
                     .id = test_fixture->kBob},

--- a/test/mock/core/consensus/grandpa/grandpa_mock.hpp
+++ b/test/mock/core/consensus/grandpa/grandpa_mock.hpp
@@ -28,17 +28,14 @@ namespace kagome::consensus::grandpa {
 
     MOCK_METHOD(void,
                 onVoteMessage,
-                (std::optional<std::shared_ptr<GrandpaContext>> &&,
-                 const PeerId &peer_id,
+                (const PeerId &,
                  std::optional<network::PeerStateCompact> &&,
-                 const VoteMessage &),
+                 VoteMessage &&),
                 (override));
 
     MOCK_METHOD(void,
                 onCommitMessage,
-                (std::optional<std::shared_ptr<GrandpaContext>> &&,
-                 const PeerId &peer_id,
-                 const network::FullCommitMessage &),
+                (const PeerId &, network::FullCommitMessage &&),
                 (override));
 
     MOCK_METHOD(outcome::result<void>,
@@ -63,9 +60,7 @@ namespace kagome::consensus::grandpa {
 
     MOCK_METHOD(void,
                 onCatchUpResponse,
-                (std::optional<std::shared_ptr<GrandpaContext>> &&,
-                 const PeerId &peer_id,
-                 const CatchUpResponse &),
+                (const PeerId &, CatchUpResponse &&),
                 (override));
 
     MOCK_METHOD(void,

--- a/test/mock/core/consensus/grandpa/voting_round_mock.hpp
+++ b/test/mock/core/consensus/grandpa/voting_round_mock.hpp
@@ -63,23 +63,17 @@ namespace kagome::consensus::grandpa {
 
     MOCK_METHOD(void,
                 onProposal,
-                (std::optional<GrandpaContext> & grandpa_context,
-                 const SignedMessage &,
-                 Propagation),
+                (OptRef<GrandpaContext>, const SignedMessage &, Propagation),
                 (override));
 
     MOCK_METHOD(bool,
                 onPrevote,
-                (std::optional<GrandpaContext> & grandpa_context,
-                 const SignedMessage &,
-                 Propagation),
+                (OptRef<GrandpaContext>, const SignedMessage &, Propagation),
                 (override));
 
     MOCK_METHOD(bool,
                 onPrecommit,
-                (std::optional<GrandpaContext> & grandpa_context,
-                 const SignedMessage &,
-                 Propagation),
+                (OptRef<GrandpaContext>, const SignedMessage &, Propagation),
                 (override));
 
     MOCK_METHOD(void,


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- fix reference to moved `PeerId`
- remove unnecessary usages of `GrandpaContext`

### Benefits

### Possible Drawbacks