### PR TITLE
bad proof

### DIFF
--- a/core/primitives/transaction_validity.cpp
+++ b/core/primitives/transaction_validity.cpp
@@ -21,8 +21,7 @@ OUTCOME_CPP_DEFINE_CATEGORY(kagome::primitives, InvalidTransaction::Kind, e) {
       return "General error to do with the transaction being outdated (e.g. "
              "nonce too low)";
     case E::BadProof:
-      return "General error to do with the transaction's proofs (e.g. "
-             "signature)";
+      return "InvalidTransaction::BadProof. General error to do with the transaction's proofs (e.g. signature). May happen if finality lags behind best block (breaks transaction mortality encoding).";
     case E::AncientBirthBlock:
       return "The transaction birth block is ancient";
     case E::ExhaustsResources:

--- a/core/runtime/wasm_edge/module_factory_impl.cpp
+++ b/core/runtime/wasm_edge/module_factory_impl.cpp
@@ -115,7 +115,7 @@ namespace kagome::runtime::wasm_edge {
           host_instance_{host_instance},
           executor_{executor},
           env_{std::move(env)},
-          code_hash_{} {
+          code_hash_{code_hash} {
       BOOST_ASSERT(module_ != nullptr);
       BOOST_ASSERT(instance_ != nullptr);
       BOOST_ASSERT(host_instance_ != nullptr);
@@ -298,8 +298,7 @@ namespace kagome::runtime::wasm_edge {
 
       InstanceEnvironment env = env_factory_->make(memory_provider);
 
-      register_host_api(
-          *env.host_api, module_.raw(), host_instance->raw());
+      register_host_api(*env.host_api, module_.raw(), host_instance->raw());
       WasmEdge_UNWRAP(WasmEdge_ExecutorRegisterImport(
           executor_->raw(), store.raw(), host_instance->raw()));
 


### PR DESCRIPTION
### Referenced issues
- #1466

### Description of the Change
- wasmedge `ModuleInstance.code_hash_`, which is used by `RuntimePropertiesCacheImpl` , was not initialized. `Executor.call` cached wrong/old/genesis `Core_version`. `version.spec_version` and `version.transaction_version` is part of signing payload, so signer (js) and verifier (wasm) didn't agree.
- explain `InvalidTransaction::BadProof`. Mortality `Era` encoding breaks if finalized block is used and finality lags.

### Benefits

### Possible Drawbacks