### PR TITLE
thread safe timer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,6 +155,7 @@ jobs:
           du -hd1 /__w /github || true
 
   clang-tidy:
+    if: ${{ !(github.ref == 'refs/heads/master' || startsWith( github.ref, 'refs/tags/' )) }}
     name: "Linux: clang-tidy"
     runs-on: ubuntu-latest
     container: qdrvm/kagome-dev@sha256:2d70246c32418a3dd45c246d3f5c2dd99bdafde145b903271849affe476c4cfc

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+add_subdirectory(aio)
 add_subdirectory(api)
 add_subdirectory(application)
 add_subdirectory(authority_discovery)

--- a/core/aio/CMakeLists.txt
+++ b/core/aio/CMakeLists.txt
@@ -1,0 +1,12 @@
+#
+# Copyright Quadrivium LLC
+# All Rights Reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+
+add_library(aio
+    impl/timer.cpp
+    )
+target_link_libraries(aio
+    p2p::p2p
+    )

--- a/core/aio/cancel.hpp
+++ b/core/aio/cancel.hpp
@@ -1,0 +1,24 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <memory>
+
+namespace kagome::aio {
+  /**
+   * Interface with destructor for `std::unique_ptr`.
+   */
+  class CancelDtor {
+   public:
+    virtual ~CancelDtor() = default;
+  };
+
+  /**
+   * RAII object to cancel operation.
+   */
+  using Cancel = std::unique_ptr<CancelDtor>;
+}  // namespace kagome::aio

--- a/core/aio/impl/timer.cpp
+++ b/core/aio/impl/timer.cpp
@@ -1,0 +1,88 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "aio/impl/timer.hpp"
+
+#include <boost/asio/io_context.hpp>
+
+namespace kagome::aio {
+  TimerImplCancel::State::~State() {
+    SAFE_UNIQUE(handle) {
+      handle.reset();
+    };
+  }
+
+  TimerImplCancel::TimerImplCancel(std::weak_ptr<boost::asio::io_context> io,
+                                   std::shared_ptr<State> state)
+      : io_{std::move(io)}, state_{std::move(state)} {}
+
+  TimerImplCancel::~TimerImplCancel() {
+    state_->cancelled.store(true);
+    auto io = io_.lock();
+    if (not io) {
+      return;
+    }
+    io->post([state{std::move(state_)}]() mutable { state.reset(); });
+  }
+
+  TimerImpl::TimerImpl(std::weak_ptr<boost::asio::io_context> io,
+                       std::weak_ptr<libp2p::basic::Scheduler> scheduler)
+      : io_{std::move(io)}, scheduler_{std::move(scheduler)} {}
+
+  void TimerImpl::timer(Cb cb, Delay delay) {
+    auto io = io_.lock();
+    if (not io) {
+      return;
+    }
+    io->post([weak_scheduler{scheduler_}, cb{std::move(cb)}, delay]() mutable {
+      auto scheduler = weak_scheduler.lock();
+      if (not scheduler) {
+        return;
+      }
+      scheduler->schedule(std::move(cb), delay);
+    });
+  }
+
+  Cancel TimerImpl::timerCancel(Cb cb, Delay delay) {
+    auto io = io_.lock();
+    if (not io) {
+      return Cancel{};
+    }
+    auto state = std::make_shared<TimerImplCancel::State>();
+    io->post([weak_scheduler{scheduler_},
+              cb{std::move(cb)},
+              delay,
+              weak_state{std::weak_ptr{state}}]() mutable {
+      auto state = weak_state.lock();
+      if (not state) {
+        return;
+      }
+      if (state->cancelled.load()) {
+        return;
+      }
+      auto scheduler = weak_scheduler.lock();
+      if (not scheduler) {
+        return;
+      }
+      cb = [cb{std::move(cb)}, weak_state]() mutable {
+        auto state = weak_state.lock();
+        if (not state) {
+          return;
+        }
+        if (state->cancelled.load()) {
+          return;
+        }
+        cb();
+      };
+      auto handle = scheduler->scheduleWithHandle(std::move(cb), delay);
+      auto &handle_out = state->handle;
+      SAFE_UNIQUE(handle_out) {
+        handle_out = std::move(handle);
+      };
+    });
+    return std::make_unique<TimerImplCancel>(io_, std::move(state));
+  }
+}  // namespace kagome::aio

--- a/core/aio/impl/timer.hpp
+++ b/core/aio/impl/timer.hpp
@@ -1,0 +1,62 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "aio/timer.hpp"
+
+#include <atomic>
+#include <libp2p/basic/scheduler.hpp>
+#include <optional>
+
+#include "common/spin_lock.hpp"
+#include "utils/safe_object.hpp"
+
+namespace boost::asio {
+  class io_context;
+}  // namespace boost::asio
+
+namespace kagome::aio {
+  /**
+   * Destroys `libp2p::basic::Scheduler::Handle` on libp2p thread.
+   */
+  class TimerImplCancel : public CancelDtor {
+   public:
+    struct State {
+      ~State();
+
+      std::atomic_bool cancelled = false;
+      SafeObject<std::optional<libp2p::basic::Scheduler::Handle>,
+                 common::spin_lock>
+          handle;
+    };
+
+    TimerImplCancel(std::weak_ptr<boost::asio::io_context> io,
+                    std::shared_ptr<State> state);
+
+    ~TimerImplCancel() override;
+
+   private:
+    std::weak_ptr<boost::asio::io_context> io_;
+    std::shared_ptr<State> state_;
+  };
+
+  /**
+   * Uses `libp2p::basic::Scheduler`.
+   */
+  class TimerImpl : public Timer {
+   public:
+    TimerImpl(std::weak_ptr<boost::asio::io_context> io,
+              std::weak_ptr<libp2p::basic::Scheduler> scheduler);
+
+    void timer(Cb, Delay) override;
+    Cancel timerCancel(Cb, Delay) override;
+
+   private:
+    std::weak_ptr<boost::asio::io_context> io_;
+    std::weak_ptr<libp2p::basic::Scheduler> scheduler_;
+  };
+}  // namespace kagome::aio

--- a/core/aio/timer.fwd.hpp
+++ b/core/aio/timer.fwd.hpp
@@ -1,0 +1,14 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <memory>
+
+namespace kagome::aio {
+  class Timer;
+  using TimerPtr = std::shared_ptr<Timer>;
+}  // namespace kagome::aio

--- a/core/aio/timer.hpp
+++ b/core/aio/timer.hpp
@@ -1,0 +1,39 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <memory>
+
+#include "aio/cancel.hpp"
+#include "aio/timer.fwd.hpp"
+
+namespace kagome::aio {
+  /**
+   * Thread safe async timer.
+   */
+  class Timer {
+   public:
+    using Delay = std::chrono::milliseconds;
+    using Cb = std::function<void()>;
+
+    virtual ~Timer() = default;
+
+    virtual void timer(Cb, Delay) = 0;
+
+    virtual Cancel timerCancel(Cb, Delay) = 0;
+
+    // libp2p alias
+    void schedule(Cb cb, Delay delay) {
+      timer(std::move(cb), delay);
+    }
+    Cancel scheduleWithHandle(Cb cb, Delay delay) {
+      return timerCancel(std::move(cb), delay);
+    }
+  };
+}  // namespace kagome::aio

--- a/core/aio/timer_thread.hpp
+++ b/core/aio/timer_thread.hpp
@@ -1,0 +1,45 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "aio/timer.hpp"
+
+#include <boost/asio/io_context.hpp>
+
+namespace kagome::aio {
+  /**
+   * Calls timer callback on specified thread.
+   */
+  class TimerThread : public Timer {
+   public:
+    TimerThread(TimerPtr timer, std::weak_ptr<boost::asio::io_context> io)
+        : timer_{std::move(timer)}, io_{std::move(io)} {}
+
+    void timer(Cb cb, Delay delay) override {
+      auto io = io_.lock();
+      timer_->timer(wrap(std::move(cb)), delay);
+    }
+
+    Cancel timerCancel(Cb cb, Delay delay) override {
+      return timer_->timerCancel(wrap(std::move(cb)), delay);
+    }
+
+   private:
+    Cb wrap(Cb &&cb) {
+      return [weak_io{io_}, cb{std::move(cb)}]() mutable {
+        auto io = weak_io.lock();
+        if (not io) {
+          return;
+        }
+        io->post(std::move(cb));
+      };
+    }
+
+    TimerPtr timer_;
+    std::weak_ptr<boost::asio::io_context> io_;
+  };
+}  // namespace kagome::aio

--- a/core/authority_discovery/interval.hpp
+++ b/core/authority_discovery/interval.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <libp2p/basic/scheduler.hpp>
+#include "aio/timer.hpp"
 
 namespace kagome::authority_discovery {
   /**
@@ -19,7 +19,7 @@ namespace kagome::authority_discovery {
    public:
     ExpIncInterval(std::chrono::milliseconds initial,
                    std::chrono::milliseconds max,
-                   std::shared_ptr<libp2p::basic::Scheduler> scheduler)
+                   aio::TimerPtr scheduler)
         : delay_{initial}, max_{max}, scheduler_{scheduler} {}
 
     void start(std::function<void()> cb) {
@@ -42,8 +42,8 @@ namespace kagome::authority_discovery {
 
     std::chrono::milliseconds delay_;
     std::chrono::milliseconds max_;
-    std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
+    aio::TimerPtr scheduler_;
     std::function<void()> cb_;
-    libp2p::basic::Scheduler::Handle handle_;
+    aio::Cancel handle_;
   };
 }  // namespace kagome::authority_discovery

--- a/core/authority_discovery/publisher/address_publisher.cpp
+++ b/core/authority_discovery/publisher/address_publisher.cpp
@@ -34,8 +34,7 @@ namespace kagome::authority_discovery {
       std::shared_ptr<crypto::Ed25519Provider> ed_crypto_provider,
       std::shared_ptr<crypto::Sr25519Provider> sr_crypto_provider,
       libp2p::Host &host,
-      std::shared_ptr<libp2p::protocol::kademlia::Kademlia> kademlia,
-      std::shared_ptr<libp2p::basic::Scheduler> scheduler)
+      std::shared_ptr<libp2p::protocol::kademlia::Kademlia> kademlia)
       : authority_discovery_api_(std::move(authority_discovery_api)),
         roles_(roles),
         block_tree_(std::move(block_tree)),
@@ -44,7 +43,6 @@ namespace kagome::authority_discovery {
         sr_crypto_provider_(std::move(sr_crypto_provider)),
         host_(host),
         kademlia_(std::move(kademlia)),
-        scheduler_(std::move(scheduler)),
         log_{log::createLogger("AddressPublisher", "authority_discovery")} {
     BOOST_ASSERT(authority_discovery_api_ != nullptr);
     BOOST_ASSERT(app_state_manager != nullptr);
@@ -53,7 +51,6 @@ namespace kagome::authority_discovery {
     BOOST_ASSERT(ed_crypto_provider_ != nullptr);
     BOOST_ASSERT(sr_crypto_provider_ != nullptr);
     BOOST_ASSERT(kademlia_ != nullptr);
-    BOOST_ASSERT(scheduler_ != nullptr);
     app_state_manager->atLaunch([this] { return start(); });
     if (libp2p_key.privateKey.type == libp2p::crypto::Key::Type::Ed25519) {
       std::array<uint8_t, crypto::constants::ed25519::PRIVKEY_SIZE>

--- a/core/authority_discovery/publisher/address_publisher.hpp
+++ b/core/authority_discovery/publisher/address_publisher.hpp
@@ -8,8 +8,8 @@
 
 #include "application/app_state_manager.hpp"
 #include "blockchain/block_tree.hpp"
-#include "crypto/key_store/session_keys.hpp"
 #include "crypto/ed25519_provider.hpp"
+#include "crypto/key_store/session_keys.hpp"
 #include "crypto/sr25519_provider.hpp"
 #include "log/logger.hpp"
 #include "runtime/runtime_api/authority_discovery_api.hpp"
@@ -38,8 +38,7 @@ namespace kagome::authority_discovery {
         std::shared_ptr<crypto::Ed25519Provider> ed_crypto_provider,
         std::shared_ptr<crypto::Sr25519Provider> sr_crypto_provider,
         libp2p::Host &host,
-        std::shared_ptr<libp2p::protocol::kademlia::Kademlia> kademlia,
-        std::shared_ptr<libp2p::basic::Scheduler> scheduler);
+        std::shared_ptr<libp2p::protocol::kademlia::Kademlia> kademlia);
 
     bool start();
 
@@ -57,8 +56,6 @@ namespace kagome::authority_discovery {
 
     libp2p::Host &host_;
     std::shared_ptr<libp2p::protocol::kademlia::Kademlia> kademlia_;
-
-    std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
 
     log::Logger log_;
 

--- a/core/authority_discovery/query/query_impl.hpp
+++ b/core/authority_discovery/query/query_impl.hpp
@@ -23,6 +23,10 @@
 #include <mutex>
 #include <random>
 
+namespace kagome::common {
+  class MainThreadPool;
+}  // namespace kagome::common
+
 namespace kagome::authority_discovery {
   class QueryImpl : public Query,
                     public std::enable_shared_from_this<QueryImpl> {
@@ -43,9 +47,10 @@ namespace kagome::authority_discovery {
         std::shared_ptr<libp2p::crypto::CryptoProvider> libp2p_crypto_provider,
         std::shared_ptr<libp2p::crypto::marshaller::KeyMarshaller>
             key_marshaller,
+        common::MainThreadPool &main_thread_pool,
         libp2p::Host &host,
         std::shared_ptr<libp2p::protocol::kademlia::Kademlia> kademlia,
-        std::shared_ptr<libp2p::basic::Scheduler> scheduler);
+        aio::TimerPtr scheduler);
 
     bool start();
 
@@ -68,9 +73,9 @@ namespace kagome::authority_discovery {
     std::shared_ptr<crypto::Sr25519Provider> sr_crypto_provider_;
     std::shared_ptr<libp2p::crypto::CryptoProvider> libp2p_crypto_provider_;
     std::shared_ptr<libp2p::crypto::marshaller::KeyMarshaller> key_marshaller_;
+    std::shared_ptr<boost::asio::io_context> main_thread_;
     libp2p::Host &host_;
     std::shared_ptr<libp2p::protocol::kademlia::Kademlia> kademlia_;
-    std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
     ExpIncInterval interval_;
 
     mutable std::mutex mutex_;

--- a/core/consensus/beefy/impl/beefy_impl.cpp
+++ b/core/consensus/beefy/impl/beefy_impl.cpp
@@ -6,9 +6,7 @@
 
 #include "consensus/beefy/impl/beefy_impl.hpp"
 
-#include <libp2p/basic/scheduler/asio_scheduler_backend.hpp>
-#include <libp2p/basic/scheduler/scheduler_impl.hpp>
-
+#include "aio/timer.hpp"
 #include "application/app_state_manager.hpp"
 #include "application/chain_spec.hpp"
 #include "blockchain/block_tree.hpp"
@@ -50,7 +48,7 @@ namespace kagome::network {
       std::shared_ptr<storage::SpacedStorage> db,
       common::MainThreadPool &main_thread_pool,
       BeefyThreadPool &beefy_thread_pool,
-      std::shared_ptr<libp2p::basic::Scheduler> scheduler,
+      aio::TimerPtr scheduler,
       LazySPtr<consensus::Timeline> timeline,
       std::shared_ptr<crypto::SessionKeys> session_keys,
       LazySPtr<BeefyProtocol> beefy_protocol,

--- a/core/consensus/beefy/impl/beefy_impl.hpp
+++ b/core/consensus/beefy/impl/beefy_impl.hpp
@@ -8,8 +8,8 @@
 
 #include <map>
 
-#include <libp2p/basic/scheduler.hpp>
-
+#include "aio/cancel.hpp"
+#include "aio/timer.fwd.hpp"
 #include "consensus/beefy/beefy.hpp"
 #include "consensus/beefy/types.hpp"
 #include "injector/lazy.hpp"
@@ -67,7 +67,7 @@ namespace kagome::network {
               std::shared_ptr<storage::SpacedStorage> db,
               common::MainThreadPool &main_thread_pool,
               BeefyThreadPool &beefy_thread_pool,
-              std::shared_ptr<libp2p::basic::Scheduler> scheduler,
+              aio::TimerPtr scheduler,
               LazySPtr<consensus::Timeline> timeline,
               std::shared_ptr<crypto::SessionKeys> session_keys,
               LazySPtr<BeefyProtocol> beefy_protocol,
@@ -122,7 +122,7 @@ namespace kagome::network {
     std::shared_ptr<storage::BufferStorage> db_;
     std::shared_ptr<PoolHandler> main_pool_handler_;
     std::shared_ptr<PoolHandler> beefy_pool_handler_;
-    std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
+    aio::TimerPtr scheduler_;
     LazySPtr<consensus::Timeline> timeline_;
     std::shared_ptr<crypto::SessionKeys> session_keys_;
     LazySPtr<BeefyProtocol> beefy_protocol_;
@@ -137,7 +137,7 @@ namespace kagome::network {
     Sessions sessions_;
     std::map<primitives::BlockNumber, consensus::beefy::SignedCommitment>
         pending_justifications_;
-    libp2p::basic::Scheduler::Handle timer_;
+    aio::Cancel timer_;
 
     log::Logger log_;
   };

--- a/core/consensus/grandpa/impl/grandpa_impl.cpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.cpp
@@ -10,7 +10,7 @@
 
 #include <libp2p/common/final_action.hpp>
 
-#include "aio/timer.hpp"
+#include "aio/timer_thread.hpp"
 #include "application/app_state_manager.hpp"
 #include "blockchain/block_tree.hpp"
 #include "common/main_thread_pool.hpp"
@@ -98,7 +98,8 @@ namespace kagome::consensus::grandpa {
         main_pool_handler_{main_thread_pool.handler(app_state_manager)},
         grandpa_pool_handler_{grandpa_thread_pool.handler(app_state_manager)},
         clock_{std::move(clock)},
-        scheduler_{std::move(timer)} {
+        scheduler_{std::make_shared<aio::TimerThread>(
+            std::move(timer), grandpa_thread_pool.io_context())} {
     BOOST_ASSERT(environment_ != nullptr);
     BOOST_ASSERT(crypto_provider_ != nullptr);
     BOOST_ASSERT(authority_manager_ != nullptr);

--- a/core/consensus/timeline/impl/timeline_impl.cpp
+++ b/core/consensus/timeline/impl/timeline_impl.cpp
@@ -6,6 +6,7 @@
 
 #include "consensus/timeline/impl/timeline_impl.hpp"
 
+#include "aio/timer.hpp"
 #include "application/app_configuration.hpp"
 #include "application/app_state_manager.hpp"
 #include "blockchain/block_tree.hpp"
@@ -22,8 +23,6 @@
 #include "runtime/runtime_api/core.hpp"
 #include "storage/trie/trie_storage.hpp"
 #include "storage/trie_pruner/trie_pruner.hpp"
-
-#include <libp2p/basic/scheduler.hpp>
 
 namespace {
   constexpr const char *kIsMajorSyncing = "kagome_sub_libp2p_is_major_syncing";
@@ -50,7 +49,7 @@ namespace kagome::consensus {
       LazySPtr<network::WarpProtocol> warp_protocol,
       std::shared_ptr<consensus::grandpa::JustificationObserver>
           justification_observer,
-      std::shared_ptr<libp2p::basic::Scheduler> scheduler,
+      aio::TimerPtr scheduler,
       primitives::events::ChainSubscriptionEnginePtr chain_sub_engine,
       primitives::events::BabeStateSubscriptionEnginePtr state_sub_engine,
       std::shared_ptr<runtime::Core> core_api)

--- a/core/consensus/timeline/impl/timeline_impl.hpp
+++ b/core/consensus/timeline/impl/timeline_impl.hpp
@@ -8,6 +8,7 @@
 
 #include "consensus/timeline/timeline.hpp"
 
+#include "aio/timer.fwd.hpp"
 #include "application/sync_method.hpp"
 #include "clock/clock.hpp"
 #include "injector/lazy.hpp"
@@ -55,10 +56,6 @@ namespace kagome::runtime {
   class Core;
 }
 
-namespace libp2p::basic {
-  class Scheduler;
-}
-
 namespace kagome::consensus {
 
   class TimelineImpl final : public Timeline,
@@ -84,7 +81,7 @@ namespace kagome::consensus {
         LazySPtr<network::WarpProtocol> warp_protocol,
         std::shared_ptr<consensus::grandpa::JustificationObserver>
             justification_observer,
-        std::shared_ptr<libp2p::basic::Scheduler> scheduler,
+        aio::TimerPtr timer,
         primitives::events::ChainSubscriptionEnginePtr chain_sub_engine,
         primitives::events::BabeStateSubscriptionEnginePtr state_sub_engine,
         std::shared_ptr<runtime::Core> core_api);
@@ -151,7 +148,7 @@ namespace kagome::consensus {
     LazySPtr<network::WarpProtocol> warp_protocol_;
     std::shared_ptr<consensus::grandpa::JustificationObserver>
         justification_observer_;
-    std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
+    aio::TimerPtr scheduler_;
     primitives::events::ChainSubscriptionEnginePtr chain_sub_engine_;
     primitives::events::ChainSub chain_sub_;
     primitives::events::BabeStateSubscriptionEnginePtr state_sub_engine_;

--- a/core/dispute_coordinator/impl/dispute_coordinator_impl.cpp
+++ b/core/dispute_coordinator/impl/dispute_coordinator_impl.cpp
@@ -11,7 +11,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include "aio/timer.hpp"
+#include "aio/timer_thread.hpp"
 #include "application/app_state_manager.hpp"
 #include "authority_discovery/query/query.hpp"
 #include "blockchain/block_header_repository.hpp"
@@ -148,7 +148,8 @@ namespace kagome::dispute {
         timeline_(std::move(timeline)),
         main_pool_handler_{main_thread_pool.handler(app_state_manager)},
         dispute_thread_handler_{dispute_thread_pool.handler(app_state_manager)},
-        scheduler_{std::move(timer)},
+        scheduler_{std::make_shared<aio::TimerThread>(
+            std::move(timer), dispute_thread_pool.io_context())},
         runtime_info_(std::make_unique<RuntimeInfo>(api_, session_keys_)),
         batches_(std::make_unique<Batches>(steady_clock_, hasher_)) {
     BOOST_ASSERT(session_keys_ != nullptr);

--- a/core/dispute_coordinator/impl/dispute_coordinator_impl.hpp
+++ b/core/dispute_coordinator/impl/dispute_coordinator_impl.hpp
@@ -11,8 +11,8 @@
 
 #include <list>
 
-#include <libp2p/basic/scheduler.hpp>
-
+#include "aio/cancel.hpp"
+#include "aio/timer.fwd.hpp"
 #include "clock/impl/basic_waitable_timer.hpp"
 #include "crypto/key_store/session_keys.hpp"
 #include "crypto/sr25519_provider.hpp"
@@ -123,6 +123,7 @@ namespace kagome::dispute {
         std::shared_ptr<parachain::ApprovalDistribution> approval_distribution,
         std::shared_ptr<authority_discovery::Query> authority_discovery,
         common::MainThreadPool &main_thread_pool,
+        aio::TimerPtr timer,
         DisputeThreadPool &dispute_thread_pool,
         std::shared_ptr<network::Router> router,
         std::shared_ptr<network::PeerView> peer_view,
@@ -325,9 +326,9 @@ namespace kagome::dispute {
         queues_;
 
     /// Delay timer for establishing the rate limit.
-    std::optional<libp2p::basic::Scheduler::Handle> rate_limit_timer_;
+    std::optional<aio::Cancel> rate_limit_timer_;
 
-    std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
+    aio::TimerPtr scheduler_;
 
     std::unique_ptr<RuntimeInfo> runtime_info_;
 

--- a/core/injector/CMakeLists.txt
+++ b/core/injector/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(application_injector
     application_injector.cpp
     )
 target_link_libraries(application_injector
+    aio
     Boost::Boost.DI
     account_nonce_api
     address_publisher

--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -23,6 +23,7 @@
 
 #undef U64  // comes from OpenSSL and messes with WAVM
 
+#include "aio/impl/timer.hpp"
 #include "api/service/author/author_jrpc_processor.hpp"
 #include "api/service/author/impl/author_api_impl.hpp"
 #include "api/service/beefy/rpc.hpp"
@@ -633,6 +634,8 @@ namespace {
                   injector.template create<sptr<application::ChainSpec>>();
               return crypto::KeyStore::Config{config.keystorePath(chain_spec->id())};
             }),
+
+            di::bind<aio::Timer>.template to<aio::TimerImpl>(),
             
             // inherit host injector
             libp2p::injector::makeHostInjector(

--- a/core/network/impl/peer_manager_impl.cpp
+++ b/core/network/impl/peer_manager_impl.cpp
@@ -13,6 +13,7 @@
 #include <libp2p/protocol/kademlia/impl/peer_routing_table.hpp>
 #include <libp2p/protocol/ping.hpp>
 
+#include "aio/timer.hpp"
 #include "network/impl/protocols/beefy_protocol_impl.hpp"
 #include "network/impl/protocols/grandpa_protocol.hpp"
 #include "network/impl/protocols/parachain_protocols.hpp"
@@ -74,7 +75,7 @@ namespace kagome::network {
       libp2p::Host &host,
       std::shared_ptr<libp2p::protocol::Identify> identify,
       std::shared_ptr<libp2p::protocol::kademlia::Kademlia> kademlia,
-      std::shared_ptr<libp2p::basic::Scheduler> scheduler,
+      aio::TimerPtr scheduler,
       std::shared_ptr<StreamEngine> stream_engine,
       const application::AppConfiguration &app_config,
       std::shared_ptr<clock::SteadyClock> clock,
@@ -308,7 +309,7 @@ namespace kagome::network {
                           + app_config_.outPeers();
     const auto peer_ttl = app_config_.peeringConfig().peerTtl;
 
-    align_timer_.cancel();
+    align_timer_.reset();
 
     clearClosedPingingConnections();
 

--- a/core/network/impl/peer_manager_impl.hpp
+++ b/core/network/impl/peer_manager_impl.hpp
@@ -11,12 +11,13 @@
 #include <memory>
 #include <queue>
 
-#include <libp2p/basic/scheduler.hpp>
 #include <libp2p/event/bus.hpp>
 #include <libp2p/host/host.hpp>
 #include <libp2p/protocol/identify/identify.hpp>
 #include <libp2p/protocol/kademlia/kademlia.hpp>
 
+#include "aio/cancel.hpp"
+#include "aio/timer.fwd.hpp"
 #include "application/app_configuration.hpp"
 #include "application/app_state_manager.hpp"
 #include "application/chain_spec.hpp"
@@ -61,7 +62,7 @@ namespace kagome::network {
         libp2p::Host &host,
         std::shared_ptr<libp2p::protocol::Identify> identify,
         std::shared_ptr<libp2p::protocol::kademlia::Kademlia> kademlia,
-        std::shared_ptr<libp2p::basic::Scheduler> scheduler,
+        aio::TimerPtr scheduler,
         std::shared_ptr<StreamEngine> stream_engine,
         const application::AppConfiguration &app_config,
         std::shared_ptr<clock::SteadyClock> clock,
@@ -185,7 +186,7 @@ namespace kagome::network {
     libp2p::Host &host_;
     std::shared_ptr<libp2p::protocol::Identify> identify_;
     std::shared_ptr<libp2p::protocol::kademlia::Kademlia> kademlia_;
-    std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
+    aio::TimerPtr scheduler_;
     std::shared_ptr<StreamEngine> stream_engine_;
     const application::AppConfiguration &app_config_;
     std::shared_ptr<clock::SteadyClock> clock_;
@@ -206,7 +207,7 @@ namespace kagome::network {
 
     std::map<PeerId, PeerDescriptor> active_peers_;
     std::unordered_map<PeerId, PeerState> peer_states_;
-    libp2p::basic::Scheduler::Handle align_timer_;
+    aio::Cancel align_timer_;
     std::set<PeerId> recently_active_peers_;
 
     // metrics

--- a/core/network/impl/protocols/grandpa_protocol.cpp
+++ b/core/network/impl/protocols/grandpa_protocol.cpp
@@ -6,6 +6,7 @@
 
 #include "network/impl/protocols/grandpa_protocol.hpp"
 
+#include "aio/timer.hpp"
 #include "blockchain/block_tree.hpp"
 #include "blockchain/genesis_block_hash.hpp"
 #include "network/common.hpp"
@@ -29,7 +30,7 @@ namespace kagome::network {
       std::shared_ptr<StreamEngine> stream_engine,
       std::shared_ptr<PeerManager> peer_manager,
       const blockchain::GenesisBlockHash &genesis_hash,
-      std::shared_ptr<libp2p::basic::Scheduler> scheduler)
+      aio::TimerPtr scheduler)
       : base_(kGrandpaProtocolName,
               host,
               make_protocols(

--- a/core/network/impl/protocols/grandpa_protocol.hpp
+++ b/core/network/impl/protocols/grandpa_protocol.hpp
@@ -11,10 +11,10 @@
 #include <memory>
 #include <random>
 
-#include <libp2p/basic/scheduler.hpp>
 #include <libp2p/connection/stream.hpp>
 #include <libp2p/host/host.hpp>
 
+#include "aio/timer.fwd.hpp"
 #include "consensus/grandpa/grandpa_observer.hpp"
 #include "containers/objects_cache.hpp"
 #include "log/logger.hpp"
@@ -52,7 +52,7 @@ namespace kagome::network {
         std::shared_ptr<StreamEngine> stream_engine,
         std::shared_ptr<PeerManager> peer_manager,
         const blockchain::GenesisBlockHash &genesis_hash,
-        std::shared_ptr<libp2p::basic::Scheduler> scheduler);
+        aio::TimerPtr scheduler);
 
     bool start() override;
 
@@ -99,7 +99,7 @@ namespace kagome::network {
     const OwnPeerInfo &own_info_;
     std::shared_ptr<StreamEngine> stream_engine_;
     std::shared_ptr<PeerManager> peer_manager_;
-    std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
+    aio::TimerPtr scheduler_;
 
     std::set<std::tuple<consensus::grandpa::RoundNumber,
                         consensus::grandpa::VoterSetId>>

--- a/core/network/impl/reputation_repository_impl.hpp
+++ b/core/network/impl/reputation_repository_impl.hpp
@@ -12,8 +12,8 @@
 #include <mutex>
 #include <unordered_map>
 
-#include <libp2p/basic/scheduler.hpp>
-
+#include "aio/cancel.hpp"
+#include "aio/timer.fwd.hpp"
 #include "log/logger.hpp"
 
 namespace kagome {
@@ -34,10 +34,9 @@ namespace kagome::network {
       : public ReputationRepository,
         public std::enable_shared_from_this<ReputationRepositoryImpl> {
    public:
-    ReputationRepositoryImpl(
-        application::AppStateManager &app_state_manager,
-        common::MainThreadPool &main_thread_pool,
-        std::shared_ptr<libp2p::basic::Scheduler> scheduler);
+    ReputationRepositoryImpl(application::AppStateManager &app_state_manager,
+                             common::MainThreadPool &main_thread_pool,
+                             aio::TimerPtr scheduler);
 
     void start();
 
@@ -54,10 +53,10 @@ namespace kagome::network {
 
     mutable std::mutex mutex_;
     std::shared_ptr<PoolHandler> main_thread_;
-    std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
+    aio::TimerPtr scheduler_;
     std::unordered_map<PeerId, Reputation> reputation_table_;
 
-    libp2p::basic::Scheduler::Handle tick_handler_;
+    aio::Cancel tick_handler_;
 
     log::Logger log_;
   };

--- a/core/network/impl/synchronizer_impl.hpp
+++ b/core/network/impl/synchronizer_impl.hpp
@@ -13,8 +13,7 @@
 #include <queue>
 #include <unordered_set>
 
-#include <libp2p/basic/scheduler.hpp>
-
+#include "aio/timer.fwd.hpp"
 #include "application/app_state_manager.hpp"
 #include "application/sync_method.hpp"
 #include "consensus/timeline/block_executor.hpp"
@@ -118,7 +117,8 @@ namespace kagome::network {
         std::shared_ptr<storage::trie_pruner::TriePruner> trie_pruner,
         std::shared_ptr<network::Router> router,
         std::shared_ptr<PeerManager> peer_manager,
-        std::shared_ptr<libp2p::basic::Scheduler> scheduler,
+        std::shared_ptr<clock::SteadyClock> clock,
+        aio::TimerPtr scheduler,
         std::shared_ptr<crypto::Hasher> hasher,
         primitives::events::ChainSubscriptionEnginePtr chain_sub_engine,
         LazySPtr<consensus::Timeline> timeline,
@@ -247,7 +247,8 @@ namespace kagome::network {
     std::shared_ptr<storage::trie_pruner::TriePruner> trie_pruner_;
     std::shared_ptr<network::Router> router_;
     std::shared_ptr<PeerManager> peer_manager_;
-    std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
+    std::shared_ptr<clock::SteadyClock> clock_;
+    aio::TimerPtr scheduler_;
     std::shared_ptr<crypto::Hasher> hasher_;
     LazySPtr<consensus::Timeline> timeline_;
     std::shared_ptr<Beefy> beefy_;
@@ -304,7 +305,7 @@ namespace kagome::network {
     std::atomic_bool asking_blocks_portion_in_progress_ = false;
     std::set<libp2p::peer::PeerId> busy_peers_;
     std::unordered_set<primitives::BlockInfo> load_blocks_;
-    std::pair<primitives::BlockNumber, std::chrono::milliseconds>
+    std::pair<primitives::BlockNumber, clock::SteadyClock::TimePoint>
         load_blocks_max_{};
 
     std::map<std::tuple<libp2p::peer::PeerId, BlocksRequest::Fingerprint>,

--- a/core/parachain/approval/approval_distribution.cpp
+++ b/core/parachain/approval/approval_distribution.cpp
@@ -8,9 +8,8 @@
 
 #include <fmt/std.h>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <libp2p/basic/scheduler/asio_scheduler_backend.hpp>
-#include <libp2p/basic/scheduler/scheduler_impl.hpp>
 
+#include "aio/timer.hpp"
 #include "common/main_thread_pool.hpp"
 #include "common/visitor.hpp"
 #include "common/worker_thread_pool.hpp"
@@ -457,6 +456,7 @@ namespace kagome::parachain {
       std::shared_ptr<Pvf> pvf,
       std::shared_ptr<Recovery> recovery,
       ApprovalThreadPool &approval_thread_pool,
+      aio::TimerPtr timer,
       common::MainThreadPool &main_thread_pool,
       LazySPtr<dispute::DisputeCoordinator> dispute_coordinator)
       : approval_thread_handler_{approval_thread_pool.handler(
@@ -478,10 +478,7 @@ namespace kagome::parachain {
         recovery_(std::move(recovery)),
         main_pool_handler_{main_thread_pool.handler(app_state_manager)},
         dispute_coordinator_{std::move(dispute_coordinator)},
-        scheduler_{std::make_shared<libp2p::basic::SchedulerImpl>(
-            std::make_shared<libp2p::basic::AsioSchedulerBackend>(
-                approval_thread_pool.io_context()),
-            libp2p::basic::Scheduler::Config{})} {
+        scheduler_{std::move(timer)} {
     BOOST_ASSERT(parachain_host_);
     BOOST_ASSERT(keystore_);
     BOOST_ASSERT(peer_view_);

--- a/core/parachain/approval/approval_distribution.cpp
+++ b/core/parachain/approval/approval_distribution.cpp
@@ -9,7 +9,7 @@
 #include <fmt/std.h>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
-#include "aio/timer.hpp"
+#include "aio/timer_thread.hpp"
 #include "common/main_thread_pool.hpp"
 #include "common/visitor.hpp"
 #include "common/worker_thread_pool.hpp"
@@ -478,7 +478,8 @@ namespace kagome::parachain {
         recovery_(std::move(recovery)),
         main_pool_handler_{main_thread_pool.handler(app_state_manager)},
         dispute_coordinator_{std::move(dispute_coordinator)},
-        scheduler_{std::move(timer)} {
+        scheduler_{std::make_shared<aio::TimerThread>(
+            std::move(timer), approval_thread_pool.io_context())} {
     BOOST_ASSERT(parachain_host_);
     BOOST_ASSERT(keystore_);
     BOOST_ASSERT(peer_view_);

--- a/core/parachain/approval/approval_distribution.hpp
+++ b/core/parachain/approval/approval_distribution.hpp
@@ -15,8 +15,9 @@
 #include <boost/asio/post.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <boost/variant.hpp>
-#include <libp2p/basic/scheduler.hpp>
 
+#include "aio/cancel.hpp"
+#include "aio/timer.fwd.hpp"
 #include "blockchain/block_tree.hpp"
 #include "consensus/babe/types/babe_block_header.hpp"
 #include "consensus/timeline/slots_util.hpp"
@@ -284,6 +285,7 @@ namespace kagome::parachain {
         std::shared_ptr<parachain::Pvf> pvf,
         std::shared_ptr<parachain::Recovery> recovery,
         ApprovalThreadPool &approval_thread_pool,
+        aio::TimerPtr timer,
         common::MainThreadPool &main_thread_pool,
         LazySPtr<dispute::DisputeCoordinator> dispute_coordinator);
     ~ApprovalDistribution() = default;
@@ -739,7 +741,7 @@ namespace kagome::parachain {
     std::shared_ptr<PoolHandler> main_pool_handler_;
     LazySPtr<dispute::DisputeCoordinator> dispute_coordinator_;
 
-    std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
+    aio::TimerPtr scheduler_;
 
     std::unordered_map<
         Hash,
@@ -749,9 +751,9 @@ namespace kagome::parachain {
     std::map<primitives::BlockNumber, std::unordered_set<primitives::BlockHash>>
         blocks_by_number_;
 
-    using ScheduledCandidateTimer = std::unordered_map<
-        CandidateHash,
-        std::vector<std::pair<Tick, libp2p::basic::Scheduler::Handle>>>;
+    using ScheduledCandidateTimer =
+        std::unordered_map<CandidateHash,
+                           std::vector<std::pair<Tick, aio::Cancel>>>;
     std::unordered_map<network::BlockHash, ScheduledCandidateTimer>
         active_tranches_;
 

--- a/core/parachain/availability/bitfield/signer.cpp
+++ b/core/parachain/availability/bitfield/signer.cpp
@@ -6,6 +6,7 @@
 
 #include "parachain/availability/bitfield/signer.hpp"
 
+#include "aio/timer.hpp"
 #include "log/logger.hpp"
 #include "primitives/block_header.hpp"
 
@@ -15,7 +16,7 @@ namespace kagome::parachain {
   BitfieldSigner::BitfieldSigner(
       std::shared_ptr<crypto::Hasher> hasher,
       std::shared_ptr<ValidatorSignerFactory> signer_factory,
-      std::shared_ptr<libp2p::basic::Scheduler> scheduler,
+      aio::TimerPtr scheduler,
       std::shared_ptr<runtime::ParachainHost> parachain_api,
       std::shared_ptr<AvailabilityStore> store,
       std::shared_ptr<Fetch> fetch,

--- a/core/parachain/availability/bitfield/signer.hpp
+++ b/core/parachain/availability/bitfield/signer.hpp
@@ -6,8 +6,7 @@
 
 #pragma once
 
-#include <libp2p/basic/scheduler.hpp>
-
+#include "aio/timer.fwd.hpp"
 #include "crypto/hasher.hpp"
 #include "log/logger.hpp"
 #include "parachain/availability/bitfield/store.hpp"
@@ -27,7 +26,7 @@ namespace kagome::parachain {
 
     BitfieldSigner(std::shared_ptr<crypto::Hasher> hasher,
                    std::shared_ptr<ValidatorSignerFactory> signer_factory,
-                   std::shared_ptr<libp2p::basic::Scheduler> scheduler,
+                   aio::TimerPtr scheduler,
                    std::shared_ptr<runtime::ParachainHost> parachain_api,
                    std::shared_ptr<AvailabilityStore> store,
                    std::shared_ptr<Fetch> fetch,
@@ -50,7 +49,7 @@ namespace kagome::parachain {
 
     std::shared_ptr<crypto::Hasher> hasher_;
     std::shared_ptr<ValidatorSignerFactory> signer_factory_;
-    std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
+    aio::TimerPtr scheduler_;
     std::shared_ptr<runtime::ParachainHost> parachain_api_;
     std::shared_ptr<AvailabilityStore> store_;
     std::shared_ptr<Fetch> fetch_;

--- a/core/parachain/pvf/kagome_pvf_worker.cpp
+++ b/core/parachain/pvf/kagome_pvf_worker.cpp
@@ -16,8 +16,6 @@
 
 #include <boost/asio.hpp>
 #include <boost/process.hpp>
-#include <libp2p/basic/scheduler/asio_scheduler_backend.hpp>
-#include <libp2p/basic/scheduler/scheduler_impl.hpp>
 #include <libp2p/common/asio_buffer.hpp>
 
 #include "common/bytestr.hpp"

--- a/core/parachain/pvf/pvf_impl.cpp
+++ b/core/parachain/pvf/pvf_impl.cpp
@@ -135,7 +135,7 @@ namespace kagome::parachain {
   PvfImpl::PvfImpl(
       const Config &config,
       std::shared_ptr<boost::asio::io_context> io_context,
-      std::shared_ptr<libp2p::basic::Scheduler> scheduler,
+      aio::TimerPtr scheduler,
       std::shared_ptr<crypto::Hasher> hasher,
       std::shared_ptr<runtime::ModuleFactory> module_factory,
       std::shared_ptr<runtime::InstrumentWasm> instrument,

--- a/core/parachain/pvf/pvf_impl.hpp
+++ b/core/parachain/pvf/pvf_impl.hpp
@@ -10,6 +10,7 @@
 
 #include <thread>
 
+#include "aio/timer.fwd.hpp"
 #include "crypto/sr25519_provider.hpp"
 #include "log/logger.hpp"
 #include "runtime/runtime_api/parachain_host.hpp"
@@ -17,10 +18,6 @@
 namespace boost::asio {
   class io_context;
 }  // namespace boost::asio
-
-namespace libp2p::basic {
-  class Scheduler;
-}  // namespace libp2p::basic
 
 namespace kagome::application {
   class AppConfiguration;
@@ -84,7 +81,7 @@ namespace kagome::parachain {
 
     PvfImpl(const Config &config,
             std::shared_ptr<boost::asio::io_context> io_context,
-            std::shared_ptr<libp2p::basic::Scheduler> scheduler,
+            aio::TimerPtr scheduler,
             std::shared_ptr<crypto::Hasher> hasher,
             std::shared_ptr<runtime::ModuleFactory> module_factory,
             std::shared_ptr<runtime::InstrumentWasm> instrument,
@@ -127,7 +124,7 @@ namespace kagome::parachain {
 
     Config config_;
     std::shared_ptr<boost::asio::io_context> io_context_;
-    std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
+    aio::TimerPtr scheduler_;
     std::shared_ptr<crypto::Hasher> hasher_;
     std::shared_ptr<blockchain::BlockTree> block_tree_;
     std::shared_ptr<crypto::Sr25519Provider> sr25519_provider_;

--- a/core/parachain/pvf/run_worker.hpp
+++ b/core/parachain/pvf/run_worker.hpp
@@ -10,10 +10,9 @@
 
 #include <boost/asio.hpp>
 #include <boost/process.hpp>
-#include <libp2p/basic/scheduler/asio_scheduler_backend.hpp>
-#include <libp2p/basic/scheduler/scheduler_impl.hpp>
 #include <libp2p/common/asio_buffer.hpp>
 
+#include "aio/timer.hpp"
 #include "common/buffer.hpp"
 #include "outcome/outcome.hpp"
 
@@ -31,7 +30,7 @@ namespace kagome::parachain {
    */
   template <std::invocable<outcome::result<common::Buffer>> Cb>
   void runWorker(boost::asio::io_context &io_context,
-                 std::shared_ptr<libp2p::basic::Scheduler> scheduler,
+                 aio::TimerPtr scheduler,
                  std::chrono::milliseconds timeout,
                  const std::string &exe,
                  common::Buffer input_,

--- a/core/telemetry/impl/connection_impl.cpp
+++ b/core/telemetry/impl/connection_impl.cpp
@@ -10,6 +10,8 @@
 
 #include <openssl/tls1.h>
 
+#include "aio/timer.hpp"
+
 namespace kagome::telemetry {
 
   std::size_t TelemetryConnectionImpl::instance_ = 0;
@@ -19,7 +21,7 @@ namespace kagome::telemetry {
       const TelemetryEndpoint &endpoint,
       OnConnectedCallback callback,
       std::shared_ptr<MessagePool> message_pool,
-      std::shared_ptr<libp2p::basic::Scheduler> scheduler)
+      aio::TimerPtr scheduler)
       : io_context_{std::move(io_context)},
         endpoint_{endpoint},
         callback_{std::move(callback)},

--- a/core/telemetry/impl/connection_impl.hpp
+++ b/core/telemetry/impl/connection_impl.hpp
@@ -21,7 +21,9 @@
 #include <boost/beast/websocket/ssl.hpp>
 #include <boost/circular_buffer.hpp>
 #include <boost/variant.hpp>
-#include <libp2p/basic/scheduler.hpp>
+
+#include "aio/cancel.hpp"
+#include "aio/timer.fwd.hpp"
 #include "log/logger.hpp"
 #include "telemetry/impl/message_pool.hpp"
 #include "utils/asio_ssl_context_client.hpp"
@@ -53,12 +55,11 @@ namespace kagome::telemetry {
      * @param message_pool - the pool to read messages passed by handle
      * @param scheduler - scheduler for reconnecting in case of line failure
      */
-    TelemetryConnectionImpl(
-        std::shared_ptr<boost::asio::io_context> io_context,
-        const TelemetryEndpoint &endpoint,
-        OnConnectedCallback callback,
-        std::shared_ptr<MessagePool> message_pool,
-        std::shared_ptr<libp2p::basic::Scheduler> scheduler);
+    TelemetryConnectionImpl(std::shared_ptr<boost::asio::io_context> io_context,
+                            const TelemetryEndpoint &endpoint,
+                            OnConnectedCallback callback,
+                            std::shared_ptr<MessagePool> message_pool,
+                            aio::TimerPtr scheduler);
     TelemetryConnectionImpl(const TelemetryConnectionImpl &) = delete;
     TelemetryConnectionImpl(TelemetryConnectionImpl &&) = delete;
 
@@ -125,7 +126,7 @@ namespace kagome::telemetry {
     const TelemetryEndpoint endpoint_;
     OnConnectedCallback callback_;
     std::shared_ptr<MessagePool> message_pool_;
-    std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
+    aio::TimerPtr scheduler_;
     bool is_connected_ = false;
     bool shutdown_requested_ = false;
     log::Logger log_;

--- a/core/telemetry/impl/service_impl.cpp
+++ b/core/telemetry/impl/service_impl.cpp
@@ -23,7 +23,7 @@ namespace rapidjson {
 #include <libp2p/host/host.hpp>
 #include <libp2p/multi/multiaddress.hpp>
 
-#include "aio/timer.hpp"
+#include "aio/timer_thread.hpp"
 #include "common/uri.hpp"
 #include "telemetry/impl/connection_impl.hpp"
 #include "telemetry/impl/telemetry_thread_pool.hpp"
@@ -57,7 +57,8 @@ namespace kagome::telemetry {
         peer_manager_{std::move(peer_manager)},
         pool_handler_{telemetry_thread_pool.handler(app_state_manager)},
         io_context_{telemetry_thread_pool.io_context()},
-        scheduler_{std::move(timer)},
+        scheduler_{std::make_shared<aio::TimerThread>(
+            std::move(timer), telemetry_thread_pool.io_context())},
         enabled_{app_configuration_.isTelemetryEnabled()},
         log_{log::createLogger("TelemetryService", "telemetry")} {
     BOOST_ASSERT(tx_pool_);

--- a/test/core/authority_discovery/address_publisher_test.cpp
+++ b/test/core/authority_discovery/address_publisher_test.cpp
@@ -7,7 +7,6 @@
 #include "authority_discovery/publisher/address_publisher.hpp"
 
 #include <gtest/gtest.h>
-#include <mock/libp2p/basic/scheduler_mock.hpp>
 #include <mock/libp2p/crypto/key_marshaller_mock.hpp>
 #include <mock/libp2p/host/host_mock.hpp>
 
@@ -38,7 +37,6 @@ using kagome::crypto::Sr25519SecretKey;
 using kagome::network::Roles;
 using kagome::runtime::AuthorityDiscoveryApiMock;
 using libp2p::HostMock;
-using libp2p::basic::SchedulerMock;
 using libp2p::crypto::marshaller::KeyMarshallerMock;
 using libp2p::multi::Multiaddress;
 using libp2p::peer::PeerId;
@@ -76,8 +74,7 @@ struct AddressPublisherTest : public testing::Test {
                                                     ed25519_provider_,
                                                     sr25519_provider_,
                                                     *host_,
-                                                    kademlia_,
-                                                    scheduler_);
+                                                    kademlia_);
   }
 
   std::shared_ptr<AppConfigurationMock> config_ =
@@ -99,7 +96,6 @@ struct AddressPublisherTest : public testing::Test {
       std::make_shared<Sr25519ProviderMock>();
   std::shared_ptr<HostMock> host_ = std::make_shared<HostMock>();
   std::shared_ptr<KademliaMock> kademlia_ = std::make_shared<KademliaMock>();
-  std::shared_ptr<SchedulerMock> scheduler_ = std::make_shared<SchedulerMock>();
   std::shared_ptr<KeyStoreMock> crypto_store_ =
       std::make_shared<KeyStoreMock>();
   PeerInfo peer_info_{

--- a/test/core/parachain/CMakeLists.txt
+++ b/test/core/parachain/CMakeLists.txt
@@ -22,11 +22,11 @@ target_link_libraries(assignments_test
     validator_parachain
     )
 
-addtest(prospective_parachains
+addtest(prospective_parachains_test
     prospective_parachains.cpp
     )
 
-target_link_libraries(prospective_parachains
+target_link_libraries(prospective_parachains_test
     validator_parachain
     log_configurator
     )


### PR DESCRIPTION
### Referenced issues
- #2023

### Description of the Change
- `Timer` hides libp2p thread unsafe `Scheduler`, posts work to correct thread
  - `Timer.timer(Cb, Delay)`
  - `Cancel Timer.timerCancel(Cb, Delay)`
    - Thread safe cancel in destructor
    - `Cancel` interface allows both flag (don't continue/call) and callback (unsubscribe)
- replace `Scheduler.now` and `Scheduler.post` usages with `Clock.now` and `PoolHandler.post`/`io_context.post`

### Possible Drawbacks
- these changes look like wrapping each libp2p method with (mutex) strand
  - should we just make libp2p thread safe?
- separate `CancelFlag` from `TimerImplCancel::State::cancelled` and use `CancelFlag` explicitly?
- return `Cancel` object or pass [`stop_token`](https://en.cppreference.com/w/cpp/thread/stop_token) optional argument?