### PR TITLE
wasm allocator poison

### DIFF
--- a/core/runtime/common/memory_allocator.hpp
+++ b/core/runtime/common/memory_allocator.hpp
@@ -75,6 +75,7 @@ namespace kagome::runtime {
     // Offset on the tail of the last allocated MemoryImpl chunk
     uint32_t offset_;
     uint32_t max_memory_pages_num_;
+    bool poisoned_ = false;
   };
 
 }  // namespace kagome::runtime


### PR DESCRIPTION
### Referenced issues
- https://github.com/qdrvm/KAGOME-audit/issues/16

### Description of the Change
- [poison allocator if `allocate`/`deallocate` was not successful](https://github.com/paritytech/polkadot-sdk/blob/4f3d43a0c4e75caf73c1034a85590f81a9ae3809/substrate/client/allocator/src/freeing_bump.rs#L408-L417)

### Possible Drawbacks