### PR TITLE
fix executor param enum

### DIFF
--- a/core/runtime/runtime_api/parachain_host_types.hpp
+++ b/core/runtime/runtime_api/parachain_host_types.hpp
@@ -325,7 +325,7 @@ namespace kagome::runtime {
   using InboundDownwardMessage = network::InboundDownwardMessage;
   using InboundHrmpMessage = network::InboundHrmpMessage;
 
-  enum class PvfPrepTimeoutKind {
+  enum class PvfPrepTimeoutKind : uint8_t {
     /// For prechecking requests, the time period after which the preparation
     /// worker is considered
     /// unresponsive and will be killed.
@@ -340,7 +340,7 @@ namespace kagome::runtime {
   };
 
   /// Type discriminator for PVF execution timeouts
-  enum class PvfExecTimeoutKind {
+  enum class PvfExecTimeoutKind : uint8_t {
     /// The amount of time to spend on execution during backing.
     Backing,
 


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- rust `enum Foo {}` -> cpp `enum Foo : uint8_t`

### Possible Drawbacks