### PR TITLE
kademlia random walk (exponential time, peer count)

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -40,7 +40,7 @@ hunter_config(
 
 hunter_config(
     libp2p
-    VERSION 0.1.20
+    VERSION 0.1.21
     KEEP_PACKAGE_SOURCES
 )
 

--- a/cmake/Hunter/hunter-gate-url.cmake
+++ b/cmake/Hunter/hunter-gate-url.cmake
@@ -1,5 +1,5 @@
 HunterGate(
-  URL  https://github.com/qdrvm/hunter/archive/refs/tags/v0.25.3-qdrvm9.zip
-  SHA1 7f3f8ee341aaac8c400e776c8a9f28e8fc458296
+  URL  https://github.com/qdrvm/hunter/archive/refs/tags/v0.25.3-qdrvm10.zip
+  SHA1 9571399d8d091420131eb81f884521326c9d3615
   LOCAL
 )

--- a/core/application/impl/kagome_application_impl.cpp
+++ b/core/application/impl/kagome_application_impl.cpp
@@ -59,6 +59,7 @@ namespace kagome::application {
 
     kagome::telemetry::setTelemetryService(injector_.injectTelemetryService());
 
+    injector_.kademliaRandomWalk();
     injector_.injectAddressPublisher();
     injector_.injectTimeline();
 

--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -133,6 +133,7 @@
 #include "network/impl/sync_protocol_observer_impl.hpp"
 #include "network/impl/synchronizer_impl.hpp"
 #include "network/impl/transactions_transmitter_impl.hpp"
+#include "network/kademlia_random_walk.hpp"
 #include "network/warp/cache.hpp"
 #include "network/warp/protocol.hpp"
 #include "network/warp/sync.hpp"
@@ -320,7 +321,7 @@ namespace {
     kademlia_config.protocols =
         network::make_protocols("/{}/kad", genesis, chain_spec);
     kademlia_config.maxBucketSize = 1000;
-    kademlia_config.randomWalk = {.interval = random_wak_interval};
+    kademlia_config.randomWalk.enabled = false;
 
     return std::make_shared<libp2p::protocol::kademlia::Config>(
         std::move(kademlia_config));
@@ -1106,4 +1107,7 @@ namespace kagome::injector {
     return pimpl_->injector_.template create<sptr<common::MainThreadPool>>();
   }
 
+  void KagomeNodeInjector::kademliaRandomWalk() {
+    pimpl_->injector_.create<sptr<KademliaRandomWalk>>();
+  }
 }  // namespace kagome::injector

--- a/core/injector/application_injector.hpp
+++ b/core/injector/application_injector.hpp
@@ -145,6 +145,7 @@ namespace kagome::injector {
     std::shared_ptr<storage::SpacedStorage> injectStorage();
     std::shared_ptr<authority_discovery::AddressPublisher>
     injectAddressPublisher();
+    void kademliaRandomWalk();
 
     std::shared_ptr<application::mode::PrintChainInfoMode>
     injectPrintChainInfoMode();

--- a/core/network/kademlia_random_walk.hpp
+++ b/core/network/kademlia_random_walk.hpp
@@ -25,6 +25,9 @@ namespace kagome {
    */
   class KademliaRandomWalk
       : public std::enable_shared_from_this<KademliaRandomWalk> {
+    static constexpr std::chrono::seconds kWalkInitialDelay{1};
+    static constexpr size_t kExtraPeers{15};
+
    public:
     KademliaRandomWalk(
         std::shared_ptr<application::AppStateManager> app_state_manager,
@@ -33,8 +36,8 @@ namespace kagome {
         std::shared_ptr<libp2p::basic::Scheduler> scheduler,
         std::shared_ptr<network::PeerManager> peer_manager,
         std::shared_ptr<libp2p::protocol::kademlia::Kademlia> kademlia)
-        : discovery_only_if_under_num_{app_config.outPeers() + 15},
-          thread_{poolHandlerReadyMake(
+        : discovery_only_if_under_num_{app_config.outPeers() + kExtraPeers},
+          main_pool_handler_{poolHandlerReadyMake(
               this, app_state_manager, main_thread_pool, log_)},
           scheduler_{std::move(scheduler)},
           peer_manager_{std::move(peer_manager)},
@@ -63,12 +66,12 @@ namespace kagome {
     }
 
     log::Logger log_ = log::createLogger("KademliaRandomWalk");
-    uint32_t discovery_only_if_under_num_;
-    std::shared_ptr<PoolHandlerReady> thread_;
+    size_t discovery_only_if_under_num_;
+    std::shared_ptr<PoolHandlerReady> main_pool_handler_;
     std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
     std::shared_ptr<network::PeerManager> peer_manager_;
     std::shared_ptr<libp2p::protocol::kademlia::PeerRouting> kademlia_;
 
-    std::chrono::seconds delay_{1};
+    std::chrono::seconds delay_{kWalkInitialDelay};
   };
 }  // namespace kagome

--- a/core/network/kademlia_random_walk.hpp
+++ b/core/network/kademlia_random_walk.hpp
@@ -1,0 +1,74 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <libp2p/basic/scheduler.hpp>
+#include <libp2p/protocol/kademlia/peer_routing.hpp>
+
+#include "application/app_configuration.hpp"
+#include "application/app_state_manager.hpp"
+#include "common/main_thread_pool.hpp"
+#include "log/logger.hpp"
+#include "network/peer_manager.hpp"
+#include "utils/pool_handler_ready_make.hpp"
+
+namespace kagome {
+  /**
+   * Kademlia random walk:
+   * - Exponential delay.
+   * - Don't walk if enough peers are available.
+   * https://github.com/paritytech/polkadot-sdk/blob/29c8130bab0ed8216f48e47a78c602e7f0c5c1f2/substrate/client/network/src/discovery.rs#L702-L724
+   */
+  class KademliaRandomWalk
+      : public std::enable_shared_from_this<KademliaRandomWalk> {
+   public:
+    KademliaRandomWalk(
+        std::shared_ptr<application::AppStateManager> app_state_manager,
+        const application::AppConfiguration &app_config,
+        common::MainThreadPool &main_thread_pool,
+        std::shared_ptr<libp2p::basic::Scheduler> scheduler,
+        std::shared_ptr<network::PeerManager> peer_manager,
+        std::shared_ptr<libp2p::protocol::kademlia::Kademlia> kademlia)
+        : discovery_only_if_under_num_{app_config.outPeers() + 15},
+          thread_{poolHandlerReadyMake(
+              this, app_state_manager, main_thread_pool, log_)},
+          scheduler_{std::move(scheduler)},
+          peer_manager_{std::move(peer_manager)},
+          kademlia_{std::move(kademlia)} {}
+
+    bool tryStart() {
+      walk();
+      return true;
+    }
+
+   private:
+    void walk() {
+      if (peer_manager_->activePeersNumber() < discovery_only_if_under_num_) {
+        std::ignore = kademlia_->findRandomPeer();
+      }
+      auto delay = delay_;
+      delay_ = std::min(delay_ * 2, std::chrono::seconds{60});
+      auto cb = [weak_self{weak_from_this()}] {
+        auto self = weak_self.lock();
+        if (not self) {
+          return;
+        }
+        self->walk();
+      };
+      scheduler_->schedule(std::move(cb), delay);
+    }
+
+    log::Logger log_ = log::createLogger("KademliaRandomWalk");
+    uint32_t discovery_only_if_under_num_;
+    std::shared_ptr<PoolHandlerReady> thread_;
+    std::shared_ptr<libp2p::basic::Scheduler> scheduler_;
+    std::shared_ptr<network::PeerManager> peer_manager_;
+    std::shared_ptr<libp2p::protocol::kademlia::PeerRouting> kademlia_;
+
+    std::chrono::seconds delay_{1};
+  };
+}  // namespace kagome

--- a/test/mock/libp2p/protocol/kademlia/kademlia_mock.hpp
+++ b/test/mock/libp2p/protocol/kademlia/kademlia_mock.hpp
@@ -37,6 +37,8 @@ namespace libp2p::protocol::kademlia {
                 (const PeerId &, FoundPeerInfoHandler),
                 (override));
 
+    MOCK_METHOD(outcome::result<void>, findRandomPeer, (), (override));
+
     MOCK_METHOD(outcome::result<void>, bootstrap, (), (override));
 
     MOCK_METHOD(void, start, (), (override));


### PR DESCRIPTION
### Referenced issues
- #2081

### Description of the Change
- [kademlia random walk](https://github.com/paritytech/polkadot-sdk/blob/29c8130bab0ed8216f48e47a78c602e7f0c5c1f2/substrate/client/network/src/discovery.rs#L702-L724)
  - exponential time
  - check connected peer count
  - measurement shows less [`connect`](https://man7.org/linux/man-pages/man2/connect.2.html) calls

### Possible Drawbacks