### PR TITLE
lazy trace macros

### DIFF
--- a/core/log/trace_macros.hpp
+++ b/core/log/trace_macros.hpp
@@ -13,7 +13,7 @@ namespace kagome::log {
 
   template <typename Ret, typename Args>
   struct TraceFuncCall {
-    const void *caller;
+    const void *caller{};
     std::string_view func_name;
     const Ret &ret;
     Args args;

--- a/core/log/trace_macros.hpp
+++ b/core/log/trace_macros.hpp
@@ -47,7 +47,7 @@ struct fmt::formatter<kagome::log::TraceFuncCall<Ret, Args>> {
                      format_context &ctx) {
     auto out = ctx.out();
     out = fmt::format_to(out, "call '{}' from {}", v.func_name, v.caller);
-    if constexpr (std::tuple_size_v < Args >> 0) {
+    if constexpr ((std::tuple_size_v<Args>) > 0) {
       out = fmt::detail::write(out, ", args: ");
       auto first = true;
       auto f = [&](auto &arg) {

--- a/core/log/trace_macros.hpp
+++ b/core/log/trace_macros.hpp
@@ -8,56 +8,67 @@
 
 #include "log/logger.hpp"
 
-#include <boost/outcome/try.hpp>
-
 namespace kagome::log {
   struct TraceReturnVoid {};
 
-  template <typename Ret, typename... Args>
-  void trace_function_call(const Logger &logger,
-                           const void *caller,
-                           std::string_view func_name,
-                           Ret &&ret,
-                           Args &&...args) {
-    if (logger->level() >= Level::TRACE) {
-      std::string str;
-      auto to = std::back_inserter(str);
-      fmt::format_to(to, "call '{}' from {}", func_name, caller);
-      if constexpr (sizeof...(args) > 0) {
-        fmt::format_to(to, ", args: ");
-        (fmt::format_to(to, "{}, ", std::forward<Args>(args)), ...);
-      }
-      if constexpr (not std::is_same_v<Ret, TraceReturnVoid>) {
-        fmt::format_to(to, " -> ret: {}", std::forward<Ret>(ret));
-      }
-      logger->trace("{}", str);
-    }
-  }
+  template <typename Ret, typename Args>
+  struct TraceFuncCall {
+    const void *caller;
+    std::string_view func_name;
+    const Ret &ret;
+    Args args;
+  };
+  template <typename Ret, typename Args>
+  TraceFuncCall(const void *, std::string_view, const Ret &, Args)
+      -> TraceFuncCall<Ret, Args>;
 
 #ifdef NDEBUG
 
-#define _SL_TRACE_FUNC_CALL(log_name, logger, ret, ...)
+#define _SL_TRACE_FUNC_CALL(logger, ret, ...)
 
 #else
 
-#define _SL_TRACE_FUNC_CALL(log_name, logger, ret, ...)      \
-  do {                                                       \
-    auto &&log_name = (logger);                              \
-    if (log_name->level() >= ::soralog::Level::TRACE) {      \
-      ::kagome::log::trace_function_call(                    \
-          log_name, this, __FUNCTION__, ret, ##__VA_ARGS__); \
-    }                                                        \
-  } while (false)
+#define _SL_TRACE_FUNC_CALL(logger, ret, ...) \
+  SL_TRACE(logger,                            \
+           "{}",                              \
+           (::kagome::log::TraceFuncCall{     \
+               this, __FUNCTION__, ret, std::forward_as_tuple(__VA_ARGS__)}))
 
 #endif
 
 }  // namespace kagome::log
 
-#define SL_TRACE_FUNC_CALL(logger, ret, ...) \
-  _SL_TRACE_FUNC_CALL(BOOST_OUTCOME_TRY_UNIQUE_NAME, logger, ret, ##__VA_ARGS__)
+template <typename Ret, typename Args>
+struct fmt::formatter<kagome::log::TraceFuncCall<Ret, Args>> {
+  static constexpr auto parse(format_parse_context &ctx) {
+    return ctx.begin();
+  }
+  static auto format(const kagome::log::TraceFuncCall<Ret, Args> &v,
+                     format_context &ctx) {
+    auto out = ctx.out();
+    out = fmt::format_to(out, "call '{}' from {}", v.func_name, v.caller);
+    if constexpr (std::tuple_size_v < Args >> 0) {
+      out = fmt::detail::write(out, ", args: ");
+      auto first = true;
+      auto f = [&](auto &arg) {
+        if (first) {
+          first = false;
+        } else {
+          out = fmt::detail::write(out, ", ");
+        }
+        out = fmt::format_to(out, "{}", arg);
+      };
+      std::apply([&](auto &...arg) { (f(arg), ...); }, v.args);
+    }
+    if constexpr (not std::is_same_v<Ret, kagome::log::TraceReturnVoid>) {
+      out = fmt::format_to(out, " -> ret: {}", v.ret);
+    }
+    return out;
+  }
+};
 
-#define SL_TRACE_VOID_FUNC_CALL(logger, ...)            \
-  _SL_TRACE_FUNC_CALL(BOOST_OUTCOME_TRY_UNIQUE_NAME,    \
-                      logger,                           \
-                      ::kagome::log::TraceReturnVoid{}, \
-                      ##__VA_ARGS__)
+#define SL_TRACE_FUNC_CALL(logger, ret, ...) \
+  _SL_TRACE_FUNC_CALL(logger, ret, ##__VA_ARGS__)
+
+#define SL_TRACE_VOID_FUNC_CALL(logger, ...) \
+  _SL_TRACE_FUNC_CALL(logger, ::kagome::log::TraceReturnVoid{}, ##__VA_ARGS__)


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- use `SL_TRACE` macro for lazy evaluation
- fix args trailing comma

### Possible Drawbacks