### PR TITLE
precompile wasm

### DIFF
--- a/core/application/CMakeLists.txt
+++ b/core/application/CMakeLists.txt
@@ -67,6 +67,7 @@ target_link_libraries(app_state_manager
 kagome_install(app_state_manager)
 
 add_library(application_modes
+    modes/precompile_wasm.cpp
     modes/print_chain_info_mode.cpp
     )
 target_link_libraries(application_modes

--- a/core/application/app_configuration.hpp
+++ b/core/application/app_configuration.hpp
@@ -32,6 +32,10 @@ namespace kagome::application {
     uint16_t times;
   };
 
+  struct PrecompileWasmConfig {
+    std::vector<filesystem::path> parachains;
+  };
+
   using BenchmarkConfigSection = std::variant<BlockBenchmarkConfig>;
 
   /**
@@ -207,8 +211,8 @@ namespace kagome::application {
      * List of telemetry endpoints specified via CLI argument or config file
      * @return a vector of parsed telemetry endpoints
      */
-    virtual const std::vector<telemetry::TelemetryEndpoint> &
-    telemetryEndpoints() const = 0;
+    virtual const std::vector<telemetry::TelemetryEndpoint>
+        &telemetryEndpoints() const = 0;
 
     /**
      * @return enum constant of the chosen sync method
@@ -314,6 +318,8 @@ namespace kagome::application {
 
     virtual std::optional<BenchmarkConfigSection> getBenchmarkConfig()
         const = 0;
+
+    virtual std::optional<PrecompileWasmConfig> precompileWasm() const = 0;
   };
 
 }  // namespace kagome::application

--- a/core/application/impl/app_configuration_impl.hpp
+++ b/core/application/impl/app_configuration_impl.hpp
@@ -235,6 +235,9 @@ namespace kagome::application {
     bool disableSecureMode() const override {
       return disable_secure_mode_;
     }
+    std::optional<PrecompileWasmConfig> precompileWasm() const override {
+      return precompile_wasm_;
+    }
 
    private:
     void parse_general_segment(const rapidjson::Value &val);
@@ -387,6 +390,7 @@ namespace kagome::application {
     bool use_pvf_subprocess_{true};
     std::chrono::milliseconds pvf_subprocess_deadline_{2000};
     bool disable_secure_mode_{false};
+    std::optional<PrecompileWasmConfig> precompile_wasm_;
   };
 
 }  // namespace kagome::application

--- a/core/application/impl/kagome_application_impl.hpp
+++ b/core/application/impl/kagome_application_impl.hpp
@@ -16,6 +16,7 @@ namespace kagome::injector {
 }
 
 namespace kagome::application {
+  class Mode;
 
   class KagomeApplicationImpl final : public KagomeApplication {
     template <class T>
@@ -31,11 +32,15 @@ namespace kagome::application {
 
     int chainInfo() override;
 
+    int precompileWasm() override;
+
     int recovery() override;
 
     void run() override;
 
    private:
+    int runMode(Mode &mode);
+
     injector::KagomeNodeInjector &injector_;
 
     std::shared_ptr<AppConfiguration> app_config_;

--- a/core/application/kagome_application.hpp
+++ b/core/application/kagome_application.hpp
@@ -18,6 +18,9 @@ namespace kagome::application {
     /// Prints chain info
     virtual int chainInfo() = 0;
 
+    /// Precompile wasm
+    virtual int precompileWasm() = 0;
+
     /// Runs recovery mode
     virtual int recovery() = 0;
 

--- a/core/application/modes/precompile_wasm.cpp
+++ b/core/application/modes/precompile_wasm.cpp
@@ -1,0 +1,68 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "application/modes/precompile_wasm.hpp"
+
+#include "blockchain/block_tree.hpp"
+#include "common/bytestr.hpp"
+#include "parachain/pvf/session_params.hpp"
+#include "runtime/common/uncompress_code_if_needed.hpp"
+#include "runtime/module_factory.hpp"
+#include "runtime/wabt/instrument.hpp"
+#include "utils/read_file.hpp"
+
+namespace kagome::application::mode {
+  PrecompileWasmMode::PrecompileWasmMode(
+      const application::AppConfiguration &app_config,
+      std::shared_ptr<blockchain::BlockTree> block_tree,
+      std::shared_ptr<runtime::ParachainHost> parachain_api,
+      std::shared_ptr<runtime::ModuleFactory> module_factory)
+      : log_{log::createLogger("PrecompileWasm")},
+        config_{*app_config.precompileWasm()},
+        block_tree_{std::move(block_tree)},
+        parachain_api_{std::move(parachain_api)},
+        module_factory_{std::move(module_factory)} {}
+
+  int PrecompileWasmMode::run() const {
+    auto r = runOutcome();
+    if (not r) {
+      SL_ERROR(log_, "runOutcome: {}", r.error());
+      return EXIT_FAILURE;
+    }
+    return EXIT_SUCCESS;
+  }
+
+  outcome::result<void> PrecompileWasmMode::runOutcome() const {
+    auto block = block_tree_->bestBlock();
+
+    // relay already precompiled, when getting version for genesis state
+
+    for (auto &path : config_.parachains) {
+      SL_INFO(log_, "precompile parachain {}", path.string());
+      Buffer bytes;
+      if (not readFile(bytes, path)) {
+        SL_WARN(log_, "read error, file {}", path.string());
+        continue;
+      }
+      auto text = byte2str(bytes);
+      if (text.starts_with("{")) {
+        SL_WARN(log_, "expected WASM, got JSON, file {}", path.string());
+        continue;
+      }
+      if (text.starts_with("0x")) {
+        BOOST_OUTCOME_TRY(bytes, common::unhexWith0x(text));
+      }
+      Buffer code;
+      OUTCOME_TRY(runtime::uncompressCodeIfNeeded(bytes, code));
+      OUTCOME_TRY(config,
+                  parachain::sessionParams(*parachain_api_, block.hash));
+      BOOST_OUTCOME_TRY(
+          code, runtime::prepareBlobForCompilation(code, config.memory_limits));
+      OUTCOME_TRY(module_factory_->make(code));
+    }
+    return outcome::success();
+  }
+}  // namespace kagome::application::mode

--- a/core/application/modes/precompile_wasm.hpp
+++ b/core/application/modes/precompile_wasm.hpp
@@ -1,0 +1,44 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "application/app_configuration.hpp"
+#include "application/mode.hpp"
+#include "log/logger.hpp"
+
+namespace kagome::blockchain {
+  class BlockTree;
+}  // namespace kagome::blockchain
+
+namespace kagome::runtime {
+  class ModuleFactory;
+  class ParachainHost;
+}  // namespace kagome::runtime
+
+namespace kagome::application::mode {
+  /**
+   * Precompile WASM before tests to avoid compilation during tests.
+   */
+  class PrecompileWasmMode final : public Mode {
+   public:
+    PrecompileWasmMode(const application::AppConfiguration &app_config,
+                       std::shared_ptr<blockchain::BlockTree> block_tree,
+                       std::shared_ptr<runtime::ParachainHost> parachain_api,
+                       std::shared_ptr<runtime::ModuleFactory> module_factory);
+
+    int run() const override;
+
+   private:
+    outcome::result<void> runOutcome() const;
+
+    log::Logger log_;
+    application::PrecompileWasmConfig config_;
+    std::shared_ptr<blockchain::BlockTree> block_tree_;
+    std::shared_ptr<runtime::ParachainHost> parachain_api_;
+    std::shared_ptr<runtime::ModuleFactory> module_factory_;
+  };
+}  // namespace kagome::application::mode

--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -48,6 +48,7 @@
 #include "application/app_configuration.hpp"
 #include "application/impl/app_state_manager_impl.hpp"
 #include "application/impl/chain_spec_impl.hpp"
+#include "application/modes/precompile_wasm.hpp"
 #include "application/modes/print_chain_info_mode.hpp"
 #include "application/modes/recovery_mode.hpp"
 #include "authority_discovery/publisher/address_publisher.hpp"
@@ -1061,6 +1062,12 @@ namespace kagome::injector {
   KagomeNodeInjector::injectPrintChainInfoMode() {
     return pimpl_->injector_
         .create<sptr<application::mode::PrintChainInfoMode>>();
+  }
+
+  sptr<application::mode::PrecompileWasmMode>
+  KagomeNodeInjector::injectPrecompileWasmMode() {
+    return pimpl_->injector_
+        .create<sptr<application::mode::PrecompileWasmMode>>();
   }
 
   std::shared_ptr<application::mode::RecoveryMode>

--- a/core/injector/application_injector.hpp
+++ b/core/injector/application_injector.hpp
@@ -27,6 +27,7 @@ namespace kagome {
 
   namespace application::mode {
     class PrintChainInfoMode;
+    class PrecompileWasmMode;
     class RecoveryMode;
     class BenchmarkMode;
   }  // namespace application::mode
@@ -149,6 +150,8 @@ namespace kagome::injector {
 
     std::shared_ptr<application::mode::PrintChainInfoMode>
     injectPrintChainInfoMode();
+    std::shared_ptr<application::mode::PrecompileWasmMode>
+    injectPrecompileWasmMode();
     std::shared_ptr<application::mode::RecoveryMode> injectRecoveryMode();
     std::shared_ptr<benchmark::BlockExecutionBenchmark> injectBlockBenchmark();
 

--- a/core/runtime/heap_alloc_strategy_heappages.hpp
+++ b/core/runtime/heap_alloc_strategy_heappages.hpp
@@ -7,13 +7,15 @@
 #pragma once
 
 #include "runtime/heap_alloc_strategy.hpp"
+#include "storage/buffer_map_types.hpp"
 #include "storage/predefined_keys.hpp"
-#include "storage/trie/trie_batches.hpp"
 
 namespace kagome {
+  constexpr uint32_t kDefaultHeapAllocPages = 2048;
+
   /// Convert ":heappages" from state trie to `HeapAllocStrategy`.
   inline outcome::result<std::optional<HeapAllocStrategy>>
-  heapAllocStrategyHeappages(const storage::trie::TrieBatch &trie) {
+  heapAllocStrategyHeappages(const storage::BufferStorage &trie) {
     OUTCOME_TRY(raw, trie.tryGet(storage::kRuntimeHeappagesKey));
     if (raw) {
       if (auto r = scale::decode<uint64_t>(*raw)) {
@@ -21,5 +23,11 @@ namespace kagome {
       }
     }
     return std::nullopt;
+  }
+
+  inline outcome::result<HeapAllocStrategy> heapAllocStrategyHeappagesDefault(
+      const storage::BufferStorage &trie) {
+    OUTCOME_TRY(config, heapAllocStrategyHeappages(trie));
+    return config.value_or(HeapAllocStrategyStatic{kDefaultHeapAllocPages});
   }
 }  // namespace kagome

--- a/core/runtime/runtime_api/impl/core.cpp
+++ b/core/runtime/runtime_api/impl/core.cpp
@@ -17,9 +17,11 @@ namespace kagome::runtime {
   outcome::result<primitives::Version> callCoreVersion(
       const ModuleFactory &module_factory,
       common::BufferView code,
+      const MemoryLimits &config,
       const std::shared_ptr<RuntimePropertiesCache> &runtime_properties_cache) {
     OUTCOME_TRY(ctx,
-                runtime::RuntimeContextFactory::fromCode(module_factory, code));
+                runtime::RuntimeContextFactory::fromCode(
+                    module_factory, code, {config}));
     return runtime_properties_cache->getVersion(
         ctx.module_instance->getCodeHash(),
         [&ctx]() -> outcome::result<primitives::Version> {

--- a/core/runtime/runtime_api/impl/core.hpp
+++ b/core/runtime/runtime_api/impl/core.hpp
@@ -18,6 +18,7 @@ namespace kagome::runtime {
   outcome::result<primitives::Version> callCoreVersion(
       const ModuleFactory &module_factory,
       common::BufferView code,
+      const MemoryLimits &config,
       const std::shared_ptr<RuntimePropertiesCache> &runtime_properties_cache);
 
   class RestrictedCoreImpl final : public RestrictedCore {

--- a/core/runtime/runtime_context.hpp
+++ b/core/runtime/runtime_context.hpp
@@ -72,7 +72,7 @@ namespace kagome::runtime {
     static outcome::result<RuntimeContext> fromCode(
         const runtime::ModuleFactory &module_factory,
         common::BufferView code_zstd,
-        ContextParams params = {});
+        ContextParams params);
 
     virtual outcome::result<RuntimeContext> fromBatch(
         std::shared_ptr<ModuleInstance> module_instance,

--- a/node/dlopen.c
+++ b/node/dlopen.c
@@ -5,15 +5,21 @@
  */
 
 #include <dlfcn.h>
+#include <mach-o/dyld.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 int main(int argc, char **argv) {
+  uint32_t size = 0;
+  _NSGetExecutablePath(NULL, &size);
+  char *exe = (char *)malloc(size);
+  _NSGetExecutablePath(exe, &size);
+
   const char *suffix = ".dylib";
-  char *dylib = (char *)malloc(strlen(argv[0]) + strlen(suffix) + 1);
-  strcpy(dylib, argv[0]);
-  strcpy(dylib + strlen(argv[0]), suffix);
+  char *dylib = (char *)malloc(strlen(exe) + strlen(suffix) + 1);
+  strcpy(dylib, exe);
+  strcpy(dylib + strlen(exe), suffix);
 
   void *lib = dlopen(dylib, RTLD_NOW);
   if (lib == NULL) {

--- a/node/main.cpp
+++ b/node/main.cpp
@@ -60,6 +60,10 @@ namespace {
       }
     }
 
+    if (configuration->precompileWasm()) {
+      return app->precompileWasm();
+    }
+
     // Recovery mode
     if (configuration->recoverState().has_value()) {
       return app->recovery();

--- a/test/mock/core/application/app_configuration_mock.hpp
+++ b/test/mock/core/application/app_configuration_mock.hpp
@@ -195,6 +195,11 @@ namespace kagome::application {
                 getBenchmarkConfig,
                 (),
                 (const, override));
+
+    MOCK_METHOD(std::optional<PrecompileWasmConfig>,
+                precompileWasm,
+                (),
+                (const, override));
   };
 
 }  // namespace kagome::application

--- a/zombienet/precompile.sh
+++ b/zombienet/precompile.sh
@@ -1,0 +1,27 @@
+#!/bin/sh -eux
+#
+# Copyright Quadrivium LLC
+# All Rights Reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+
+DIR=.zombienet-precompile
+mkdir -p $DIR
+echo '*' > $DIR/.gitignore
+
+polkadot build-spec --chain rococo-local --raw > $DIR/rococo-local.json
+adder-collator export-genesis-wasm > $DIR/adder-collator.json
+undying-collator export-genesis-wasm > $DIR/undying-collator.json
+polkadot-parachain export-genesis-wasm > $DIR/polkadot-parachain.json
+polkadot build-spec --chain westend-local --raw > $DIR/westend-local.json
+
+kagome --tmp --chain $DIR/rococo-local.json \
+  --precompile-para $DIR/adder-collator.json \
+  --precompile-para $DIR/undying-collator.json \
+  --precompile-para $DIR/polkadot-parachain.json
+
+kagome --tmp --chain $DIR/westend-local.json \
+  --precompile-para $DIR/polkadot-parachain.json
+
+kagome --tmp --chain kagome/zombienet/0009-basic-warp-sync/gen-db-raw.json \
+  --precompile-relay


### PR DESCRIPTION
### Referenced issues
- closes #2099

### Description of the Change
- `--precompile-relay` and `--precompile-para FILE` flags
- `zombienet/precompile.sh` to precompile wasm before zombie tests
- fix double compilation of genesis (missing config)
- fix `--chain-info` not stopping
- fix macos `dlopen` when "kagome" is started via `PATH`.

### Possible Drawbacks
- `zombienet/precompile.sh` not called on CI, don't know where