### PR TITLE
fix grandpa catchup

### DIFF
--- a/core/consensus/grandpa/impl/grandpa_impl.cpp
+++ b/core/consensus/grandpa/impl/grandpa_impl.cpp
@@ -791,7 +791,7 @@ namespace kagome::consensus::grandpa {
     }
 
     GrandpaContext grandpa_context;
-    VotingRoundUpdate update{*current_round_, grandpa_context};
+    VotingRoundUpdate update{*round, grandpa_context};
     for (auto &vote : msg.prevote_justification) {
       update.vote(vote);
     }


### PR DESCRIPTION
### Referenced issues
- bug after #1977

### Description of the Change
- "invalid signature" (wrong round after catchup)

### Possible Drawbacks