### PR TITLE
remove unused `Readable::empty`

### DIFF
--- a/core/storage/face/readable.hpp
+++ b/core/storage/face/readable.hpp
@@ -29,11 +29,6 @@ namespace kagome::storage::face {
     virtual outcome::result<bool> contains(const View<K> &key) const = 0;
 
     /**
-     * @brief Returns true if the storage is empty.
-     */
-    virtual bool empty() const = 0;
-
-    /**
      * @brief Get value by key
      * @param key K
      * @return V

--- a/core/storage/in_memory/in_memory_storage.cpp
+++ b/core/storage/in_memory/in_memory_storage.cpp
@@ -49,10 +49,6 @@ namespace kagome::storage {
     return storage.find(key.toHex()) != storage.end();
   }
 
-  bool InMemoryStorage::empty() const {
-    return storage.empty();
-  }
-
   outcome::result<void> InMemoryStorage::remove(const BufferView &key) {
     auto it = storage.find(key.toHex());
     if (it != storage.end()) {

--- a/core/storage/in_memory/in_memory_storage.hpp
+++ b/core/storage/in_memory/in_memory_storage.hpp
@@ -35,8 +35,6 @@ namespace kagome::storage {
     outcome::result<bool> contains(
         const common::BufferView &key) const override;
 
-    bool empty() const override;
-
     outcome::result<void> remove(const common::BufferView &key) override;
 
     std::unique_ptr<BufferBatch> batch() override;

--- a/core/storage/map_prefix/prefix.cpp
+++ b/core/storage/map_prefix/prefix.cpp
@@ -126,10 +126,6 @@ namespace kagome::storage {
     return map->contains(_key(key));
   }
 
-  bool MapPrefix::empty() const {
-    throw std::logic_error{"MapPrefix::empty not implemented"};
-  }
-
   outcome::result<void> MapPrefix::put(const BufferView &key,
                                        BufferOrView &&value) {
     return map->put(_key(key), std::move(value));

--- a/core/storage/map_prefix/prefix.hpp
+++ b/core/storage/map_prefix/prefix.hpp
@@ -48,7 +48,6 @@ namespace kagome::storage {
     Buffer _key(BufferView key) const;
 
     outcome::result<bool> contains(const BufferView &key) const override;
-    bool empty() const override;
     outcome::result<BufferOrView> get(const BufferView &key) const override;
     outcome::result<std::optional<BufferOrView>> tryGet(
         const BufferView &key) const override;

--- a/core/storage/rocksdb/rocksdb.cpp
+++ b/core/storage/rocksdb/rocksdb.cpp
@@ -233,17 +233,6 @@ namespace kagome::storage {
     return status_as_error(status);
   }
 
-  bool RocksDbSpace::empty() const {
-    auto rocks = storage_.lock();
-    if (!rocks) {
-      return true;
-    }
-    auto it = std::unique_ptr<rocksdb::Iterator>(
-        rocks->db_->NewIterator(rocks->ro_, column_));
-    it->SeekToFirst();
-    return it->Valid();
-  }
-
   outcome::result<BufferOrView> RocksDbSpace::get(const BufferView &key) const {
     OUTCOME_TRY(rocks, use());
     std::string value;

--- a/core/storage/rocksdb/rocksdb.hpp
+++ b/core/storage/rocksdb/rocksdb.hpp
@@ -101,8 +101,6 @@ namespace kagome::storage {
 
     outcome::result<bool> contains(const BufferView &key) const override;
 
-    bool empty() const override;
-
     outcome::result<BufferOrView> get(const BufferView &key) const override;
 
     outcome::result<std::optional<BufferOrView>> tryGet(

--- a/core/storage/trie/impl/topper_trie_batch_impl.cpp
+++ b/core/storage/trie/impl/topper_trie_batch_impl.cpp
@@ -82,21 +82,6 @@ namespace kagome::storage::trie {
     return false;
   }
 
-  bool TopperTrieBatchImpl::empty() const {
-    if (not cache_.empty()
-        and std::any_of(cache_.begin(), cache_.end(), [](auto &p) {
-              return p.second.has_value();
-            })) {
-      return false;
-    }
-    // TODO(Harrm): #2106 consider clearPrefix here. Not an easy thing and is
-    // barely possible to happen, so leave it for the future
-    if (auto p = parent_.lock(); p != nullptr) {
-      return p->empty();
-    }
-    return true;
-  }
-
   outcome::result<void> TopperTrieBatchImpl::put(const BufferView &key,
                                                  BufferOrView &&value) {
     cache_.insert_or_assign(Buffer{key}, value.intoBuffer());

--- a/core/storage/trie/impl/topper_trie_batch_impl.hpp
+++ b/core/storage/trie/impl/topper_trie_batch_impl.hpp
@@ -34,7 +34,6 @@ namespace kagome::storage::trie {
 
     std::unique_ptr<PolkadotTrieCursor> trieCursor() override;
     outcome::result<bool> contains(const BufferView &key) const override;
-    bool empty() const override;
 
     outcome::result<void> put(const BufferView &key,
                               BufferOrView &&value) override;

--- a/core/storage/trie/impl/trie_batch_base.cpp
+++ b/core/storage/trie/impl/trie_batch_base.cpp
@@ -42,10 +42,6 @@ namespace kagome::storage::trie {
     return trie_->contains(key);
   }
 
-  bool TrieBatchBase::empty() const {
-    return trie_->empty();
-  }
-
   outcome::result<std::optional<std::shared_ptr<TrieBatch>>>
   TrieBatchBase::createChildBatch(common::BufferView path) {
     OUTCOME_TRY(child_root_value, tryGet(path));

--- a/core/storage/trie/impl/trie_batch_base.hpp
+++ b/core/storage/trie/impl/trie_batch_base.hpp
@@ -35,7 +35,6 @@ namespace kagome::storage::trie {
         const BufferView &key) const override;
     std::unique_ptr<PolkadotTrieCursor> trieCursor() override;
     outcome::result<bool> contains(const BufferView &key) const override;
-    bool empty() const override;
 
     virtual outcome::result<std::optional<std::shared_ptr<TrieBatch>>>
     createChildBatch(common::BufferView path) override;

--- a/core/storage/trie/impl/trie_storage_backend_impl.cpp
+++ b/core/storage/trie/impl/trie_storage_backend_impl.cpp
@@ -43,10 +43,6 @@ namespace kagome::storage::trie {
     return storage_->contains(key);
   }
 
-  bool TrieStorageBackendImpl::empty() const {
-    return storage_->empty();
-  }
-
   outcome::result<void> TrieStorageBackendImpl::put(const BufferView &key,
                                                     BufferOrView &&value) {
     return storage_->put(key, std::move(value));

--- a/core/storage/trie/impl/trie_storage_backend_impl.hpp
+++ b/core/storage/trie/impl/trie_storage_backend_impl.hpp
@@ -26,7 +26,6 @@ namespace kagome::storage::trie {
     outcome::result<std::optional<BufferOrView>> tryGet(
         const BufferView &key) const override;
     outcome::result<bool> contains(const BufferView &key) const override;
-    bool empty() const override;
 
     outcome::result<void> put(const BufferView &key,
                               BufferOrView &&value) override;

--- a/core/storage/trie/polkadot_trie/polkadot_trie_impl.cpp
+++ b/core/storage/trie/polkadot_trie/polkadot_trie_impl.cpp
@@ -578,10 +578,6 @@ namespace kagome::storage::trie {
     return node != nullptr && node->getValue();
   }
 
-  bool PolkadotTrieImpl::empty() const {
-    return nodes_->getRoot() == nullptr;
-  }
-
   outcome::result<void> PolkadotTrieImpl::remove(
       const common::BufferView &key) {
     auto key_nibbles = KeyNibbles::fromByteBuffer(key);

--- a/core/storage/trie/polkadot_trie/polkadot_trie_impl.hpp
+++ b/core/storage/trie/polkadot_trie/polkadot_trie_impl.hpp
@@ -87,8 +87,6 @@ namespace kagome::storage::trie {
     outcome::result<bool> contains(
         const common::BufferView &key) const override;
 
-    bool empty() const override;
-
     outcome::result<ConstNodePtr> retrieveChild(const BranchNode &parent,
                                                 uint8_t idx) const override;
     outcome::result<NodePtr> retrieveChild(const BranchNode &parent,

--- a/core/utils/kagome_db_editor.cpp
+++ b/core/utils/kagome_db_editor.cpp
@@ -69,9 +69,6 @@ struct TrieTracker : TrieStorageBackend {
   outcome::result<bool> contains(const BufferView &key) const override {
     abort();
   }
-  bool empty() const override {
-    abort();
-  }
 
   outcome::result<void> put(const BufferView &key,
                             BufferOrView &&value) override {

--- a/test/core/storage/trie/polkadot_trie/polkadot_trie_test.cpp
+++ b/test/core/storage/trie/polkadot_trie/polkadot_trie_test.cpp
@@ -349,7 +349,6 @@ TEST_F(TrieTest, ClearPrefix) {
         return outcome::success();
       }));
   ASSERT_OUTCOME_IS_FALSE(trie->contains("bat"_buf));
-  ASSERT_TRUE(trie->empty());
 }
 
 struct DeleteData {
@@ -510,17 +509,6 @@ INSTANTIATE_TEST_SUITE_P(
                          {""_buf, "a"_buf},
                          {false, 2},
                          2}}));
-
-/**
- * @given an empty trie
- * @when putting something into the trie
- * @then the trie is empty no more
- */
-TEST_F(TrieTest, EmptyTrie) {
-  ASSERT_TRUE(trie->empty());
-  ASSERT_OUTCOME_SUCCESS_TRY(trie->put(Buffer{0}, "asdasd"_buf));
-  ASSERT_FALSE(trie->empty());
-}
 
 /**
  * @given a trie

--- a/test/core/storage/trie_pruner/trie_pruner_test.cpp
+++ b/test/core/storage/trie_pruner/trie_pruner_test.cpp
@@ -68,10 +68,6 @@ class PolkadotTrieMock final : public trie::PolkadotTrie {
     throw std::runtime_error{"Not implemented"};
   }
 
-  bool empty() const override {
-    throw std::runtime_error{"Not implemented"};
-  }
-
   outcome::result<face::OwnedOrView<Buffer>> get(
       const face::View<Buffer> &key) const override {
     throw std::runtime_error{"Not implemented"};

--- a/test/mock/core/storage/trie/trie_batches_mock.hpp
+++ b/test/mock/core/storage/trie/trie_batches_mock.hpp
@@ -66,8 +66,6 @@ namespace kagome::storage::trie {
                 (const common::BufferView &buf, std::optional<uint64_t> limit),
                 (override));
 
-    MOCK_METHOD(bool, empty, (), (const, override));
-
     MOCK_METHOD(outcome::result<storage::trie::RootHash>,
                 commit,
                 (StateVersion),

--- a/test/mock/core/storage/trie/trie_storage_backend_mock.hpp
+++ b/test/mock/core/storage/trie/trie_storage_backend_mock.hpp
@@ -36,8 +36,6 @@ namespace kagome::storage::trie {
                 (const BufferView &key),
                 (const, override));
 
-    MOCK_METHOD(bool, empty, (), (const, override));
-
     MOCK_METHOD(outcome::result<void>,
                 put,
                 (const BufferView &key, BufferOrView &&value),

--- a/test/testutil/storage/polkadot_trie_printer.hpp
+++ b/test/testutil/storage/polkadot_trie_printer.hpp
@@ -105,8 +105,7 @@ namespace kagome::storage::trie {
 
   template <typename Stream>
   Stream &operator<<(Stream &s, const PolkadotTrie &trie) {
-    if (not trie.empty()) {
-      auto root = trie.getRoot();
+    if (auto root = trie.getRoot()) {
       printer_internal::NodePrinter p(s);
       p.printNode(root, trie);
     }


### PR DESCRIPTION
### Referenced issues
- closes #2106

### Description of the Change
- `empty` was unused
  - if needed can use `fn is_empty(Iterable m) { m.cursor().next().is_none() }`

### Possible Drawbacks