### PR TITLE
boringssl

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -84,20 +84,13 @@ if (APPLE AND (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_CXX_COMPILER
 endif ()
 
 hunter_config(
-        wabt
-        URL https://github.com/qdrvm/wabt/archive/refs/tags/1.0.34-qdrvm1.zip
-        SHA1 d22995329c9283070f3a32d2c5e07f4d75c2fc31
-        KEEP_PACKAGE_SOURCES
-        CMAKE_ARGS
-        BUILD_TESTS=OFF
-        BUILD_TOOLS=OFF
-        BUILD_LIBWASM=OFF
-        USE_INTERNAL_SHA256=OFF
-)
-
-hunter_config(
     libsecp256k1
     VERSION 0.4.1-qdrvm1
     CMAKE_ARGS
         SECP256K1_ENABLE_MODULE_RECOVERY=ON
+)
+
+hunter_config(libp2p
+  URL  https://github.com/libp2p/cpp-libp2p/archive/e44b46754d3b58c257bb602d2ceac8b8e9c330e9.zip
+  SHA1 d9fa50676b9d859b7934a5c510a4acd485b51d6f
 )

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -89,8 +89,3 @@ hunter_config(
     CMAKE_ARGS
         SECP256K1_ENABLE_MODULE_RECOVERY=ON
 )
-
-hunter_config(libp2p
-  URL  https://github.com/libp2p/cpp-libp2p/archive/e44b46754d3b58c257bb602d2ceac8b8e9c330e9.zip
-  SHA1 d9fa50676b9d859b7934a5c510a4acd485b51d6f
-)

--- a/cmake/Hunter/hunter-gate-url.cmake
+++ b/cmake/Hunter/hunter-gate-url.cmake
@@ -1,5 +1,5 @@
 HunterGate(
-  URL  https://github.com/qdrvm/hunter/archive/refs/tags/v0.25.3-qdrvm15.zip
-  SHA1 b338eb3b6a989f19257d6d4acbc9f810abcf1b32
+  URL  https://github.com/qdrvm/hunter/archive/refs/tags/v0.25.3-qdrvm16.zip
+  SHA1 990ea05207260b3757ce051e354cc163e910a211
   LOCAL
 )

--- a/cmake/Hunter/hunter-gate-url.cmake
+++ b/cmake/Hunter/hunter-gate-url.cmake
@@ -1,5 +1,5 @@
 HunterGate(
-  URL  https://github.com/qdrvm/hunter/archive/refs/tags/v0.25.3-qdrvm13.zip
-  SHA1 4c01caa778ac85226bba7cbef4e966e2c7031b3f
+  URL  https://github.com/qdrvm/hunter/archive/refs/tags/v0.25.3-qdrvm15.zip
+  SHA1 b338eb3b6a989f19257d6d4acbc9f810abcf1b32
   LOCAL
 )

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -39,8 +39,8 @@ hunter_add_package(libp2p)
 find_package(libp2p CONFIG REQUIRED)
 
 # https://www.openssl.org/
-hunter_add_package(OpenSSL)
-find_package(OpenSSL REQUIRED)
+hunter_add_package(BoringSSL)
+find_package(OpenSSL CONFIG REQUIRED)
 
 # https://developers.google.com/protocol-buffers/
 hunter_add_package(Protobuf)

--- a/cmake/kagomeConfig.cmake.in
+++ b/cmake/kagomeConfig.cmake.in
@@ -13,7 +13,7 @@ find_dependency(erasure_coding_crust REQUIRED)
 find_dependency(schnorrkel_crust REQUIRED)
 find_dependency(zstd REQUIRED)
 find_dependency(libsecp256k1 REQUIRED)
-find_dependency(OpenSSL REQUIRED)
+find_dependency(OpenSSL CONFIG REQUIRED)
 find_dependency(RocksDB REQUIRED)
 find_dependency(scale REQUIRED)
 

--- a/core/api/transport/impl/ws/ws_session.cpp
+++ b/core/api/transport/impl/ws/ws_session.cpp
@@ -9,6 +9,7 @@
 #include <thread>
 
 #include <boost/asio/dispatch.hpp>
+#include <boost/beast/core/bind_handler.hpp>
 #include <boost/config.hpp>
 #include <libp2p/outcome/outcome.hpp>
 

--- a/core/dispute_coordinator/impl/sending_dispute.hpp
+++ b/core/dispute_coordinator/impl/sending_dispute.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "dispute_coordinator/dispute_coordinator.hpp"
+#include "log/logger.hpp"
 #include "network/types/dispute_messages.hpp"
 
 namespace kagome {

--- a/core/network/impl/state_protocol_observer_impl.cpp
+++ b/core/network/impl/state_protocol_observer_impl.cpp
@@ -5,9 +5,6 @@
  */
 
 #include "network/impl/state_protocol_observer_impl.hpp"
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/bind/storage.hpp>
-#include <libp2p/outcome/outcome.hpp>
 #include <unordered_set>
 
 #include "blockchain/block_header_repository.hpp"


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- replace `OpenSSL` with `BoringSSL` (required for [lsquic](https://github.com/litespeedtech/lsquic)).

### Possible Drawbacks
- #2129 `BoringSSL` doesn't implement "secure" heap allocator (`mlock`, `madvice(MADV_DONTDUMP)`).