### PR TITLE
binaryen memory size getter

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -74,15 +74,6 @@ if ("${WASM_COMPILER}" STREQUAL "WAVM")
   )
 endif ()
 
-# Fix for Apple clang (or clang from brew) of versions 15 and higher
-if (APPLE AND (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang") AND CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL "15.0.0")
-  hunter_config(
-      binaryen
-      URL https://github.com/qdrvm/binaryen/archive/e6a2fea157bde503f07f28444b350512374cf5bf.zip
-      SHA1 301f8b1775904179cb552c12be237b4aa076981e
-  )
-endif ()
-
 hunter_config(
     libsecp256k1
     VERSION 0.4.1-qdrvm1

--- a/cmake/Hunter/hunter-gate-url.cmake
+++ b/cmake/Hunter/hunter-gate-url.cmake
@@ -1,5 +1,5 @@
 HunterGate(
-  URL  https://github.com/qdrvm/hunter/archive/refs/tags/v0.25.3-qdrvm16.zip
-  SHA1 990ea05207260b3757ce051e354cc163e910a211
+  URL  https://github.com/qdrvm/hunter/archive/refs/tags/v0.25.3-qdrvm17.zip
+  SHA1 7b2137466c9884a56e7ce6adca8aefbe25bb43d9
   LOCAL
 )

--- a/cmake/Hunter/hunter-gate-url.cmake
+++ b/cmake/Hunter/hunter-gate-url.cmake
@@ -1,5 +1,5 @@
 HunterGate(
-  URL  https://github.com/qdrvm/hunter/archive/refs/tags/v0.25.3-qdrvm17.zip
-  SHA1 7b2137466c9884a56e7ce6adca8aefbe25bb43d9
+  URL  https://github.com/qdrvm/hunter/archive/refs/tags/v0.25.3-qdrvm18.zip
+  SHA1 22d842b448f84a39392d7835f4046da34f8dcd70
   LOCAL
 )

--- a/core/runtime/binaryen/memory_impl.cpp
+++ b/core/runtime/binaryen/memory_impl.cpp
@@ -16,9 +16,7 @@ namespace kagome::runtime::binaryen {
   MemoryImpl::MemoryImpl(RuntimeExternalInterface::InternalMemory *memory,
                          const MemoryConfig &config)
       : memory_{memory},
-        logger_{log::createLogger("Binaryen Memory", "binaryen")} {
-    memory_->resize(kInitialMemorySize);
-  }
+        logger_{log::createLogger("Binaryen Memory", "binaryen")} {}
 
   std::optional<WasmSize> MemoryImpl::pagesMax() const {
     return memory_->pagesMax();

--- a/core/runtime/binaryen/memory_impl.hpp
+++ b/core/runtime/binaryen/memory_impl.hpp
@@ -52,7 +52,7 @@ namespace kagome::runtime::binaryen {
        * deallocated_ pointers fixup
        */
       if (new_size >= size()) {
-        memory_->resize(sizeToPages(new_size) * kMemoryPageSize);
+        memory_->pagesResize(sizeToPages(new_size));
       }
     }
 

--- a/core/runtime/binaryen/module/module_impl.cpp
+++ b/core/runtime/binaryen/module/module_impl.cpp
@@ -81,8 +81,6 @@ namespace kagome::runtime::binaryen {
       }
     }
 
-    module->memory.initial = kDefaultHeappages;
-
     return std::make_shared<ModuleImpl>(
         std::move(module), module_factory, env_factory, code_hash);
   }

--- a/core/runtime/binaryen/module/module_impl.hpp
+++ b/core/runtime/binaryen/module/module_impl.hpp
@@ -33,7 +33,6 @@ namespace kagome::runtime::binaryen {
   class ModuleImpl final : public runtime::Module,
                            public std::enable_shared_from_this<ModuleImpl> {
    public:
-    static constexpr auto kDefaultHeappages = 1024;
     enum class Error { EMPTY_STATE_CODE = 1, INVALID_STATE_CODE };
 
     ModuleImpl(ModuleImpl &&) = default;

--- a/core/runtime/binaryen/runtime_external_interface.cpp
+++ b/core/runtime/binaryen/runtime_external_interface.cpp
@@ -141,7 +141,6 @@ namespace kagome::runtime::binaryen {
       std::shared_ptr<host_api::HostApi> host_api)
       : host_api_{std::move(host_api)},
         logger_{log::createLogger("RuntimeExternalInterface", "binaryen")} {
-    memory.resize(kInitialMemorySize);
     BOOST_ASSERT(host_api_);
     registerMethods();
   }
@@ -195,7 +194,7 @@ namespace kagome::runtime::binaryen {
 
   void RuntimeExternalInterface::init(wasm::Module &wasm,
                                       wasm::ModuleInstance &instance) {
-    memory.resize(wasm.memory.initial * wasm::Memory::kPageSize);
+    memory.pagesResize(wasm.memory.initial);
     if (wasm.memory.hasMax()) {
       memory.pages_max = wasm.memory.max;
     }

--- a/core/runtime/binaryen/runtime_external_interface.hpp
+++ b/core/runtime/binaryen/runtime_external_interface.hpp
@@ -52,7 +52,11 @@ namespace kagome::runtime::binaryen {
 
      public:
       Memory() = default;
-      void resize(size_t newSize) {
+      uint32_t pages() {
+        return memory.size() / ::wasm::Memory::kPageSize;
+      }
+      void pagesResize(size_t newPages) {
+        size_t newSize = newPages * ::wasm::Memory::kPageSize;
         // Ensure the smallest allocation is large enough that most allocators
         // will provide page-aligned storage. This hopefully allows the
         // interpreter's memory to be as aligned as the memory being simulated,
@@ -171,8 +175,12 @@ namespace kagome::runtime::binaryen {
       memory.set<std::array<uint8_t, 16>>(addr, value);
     }
 
-    void growMemory(wasm::Address /*oldSize*/, wasm::Address newSize) override {
-      memory.resize(newSize);
+    uint32_t memoryPages() override {
+      return memory.pages();
+    }
+
+    void memoryPagesGrow(uint32_t /*oldPages*/, uint32_t newPages) override {
+      memory.pagesResize(newPages);
     }
 
     [[noreturn]] void trap(const char *why) override {


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- `undying-collator` (functional/0001-parachains-pvf.toml) uses `dlmalloc`, but `binaryen` duplicated inconsistent memory size to private field

### Possible Drawbacks