### PR TITLE
remove ParachainHost_check_validation_outputs call

### DIFF
--- a/core/parachain/pvf/pvf_impl.cpp
+++ b/core/parachain/pvf/pvf_impl.cpp
@@ -372,18 +372,6 @@ namespace kagome::parachain {
     if (commitments_hash != receipt.commitments_hash) {
       return PvfError::COMMITMENTS_HASH;
     }
-    OUTCOME_TRY(valid,
-                parachain_api_->check_validation_outputs(
-                    receipt.descriptor.relay_parent,
-                    receipt.descriptor.para_id,
-                    commitments));
-    if (!valid) {
-      SL_VERBOSE(log_,
-                 "fromOutputs relay_parent={} para_id={}: invalid "
-                 "(check_validation_outputs)",
-                 receipt.descriptor.relay_parent,
-                 receipt.descriptor.para_id);
-    }
     return commitments;
   }
 }  // namespace kagome::parachain

--- a/core/parachain/pvf/pvf_impl.cpp
+++ b/core/parachain/pvf/pvf_impl.cpp
@@ -383,7 +383,6 @@ namespace kagome::parachain {
                  "(check_validation_outputs)",
                  receipt.descriptor.relay_parent,
                  receipt.descriptor.para_id);
-      return PvfError::OUTPUTS;
     }
     return commitments;
   }


### PR DESCRIPTION
### Referenced issues
- #2160
- https://github.com/paritytech/polkadot/pull/5022

### Description of the Change
- Polkadot removed call to `ParachainHost_check_validation_outputs` ([https://github.com/paritytech/polkadot/pull/5022/files#diff-071b05c1f9d37af19d35d6c155a5238d071e1b303bc27f45ec40e846b39541b8L643-R558](change)) and didn't use it for disputes

### Possible Drawbacks