### PR TITLE
fix recovery (validators <= discovery_keys)

### DIFF
--- a/core/parachain/availability/recovery/recovery_impl.hpp
+++ b/core/parachain/availability/recovery/recovery_impl.hpp
@@ -51,6 +51,7 @@ namespace kagome::parachain {
    private:
     struct Active {
       storage::trie::RootHash erasure_encoding_root;
+      size_t chunks_total = 0;
       size_t chunks_required = 0;
       std::vector<Cb> cb;
       std::vector<primitives::AuthorityDiscoveryId> validators;


### PR DESCRIPTION
### Referenced issues
- revert #2172

### Description of the Change
- `validators.size() <= discovery_keys.size()`, save `chunks_total = validators.size()` for erasure coding

### Possible Drawbacks