### PR TITLE
Fix payment_queryInfo

### DIFF
--- a/core/api/jrpc/value_converter.hpp
+++ b/core/api/jrpc/value_converter.hpp
@@ -102,6 +102,13 @@ namespace kagome::api {
     return ret;
   }
 
+  inline jsonrpc::Value makeValue(const primitives::Weight &val) {
+    jStruct data;
+    data["ref_time"] = static_cast<int64_t>(*val.ref_time);
+    data["proof_size"] = static_cast<int64_t>(*val.proof_size);
+    return data;
+  }
+
   inline jsonrpc::Value makeValue(const primitives::OldWeight &val) {
     jsonrpc::Value ret(static_cast<int64_t>(*val));
     return ret;

--- a/core/api/service/payment/impl/payment_api_impl.cpp
+++ b/core/api/service/payment/impl/payment_api_impl.cpp
@@ -20,7 +20,7 @@ namespace kagome::api {
     BOOST_ASSERT(block_tree_);
   }
 
-  outcome::result<primitives::RuntimeDispatchInfo<primitives::OldWeight>>
+  outcome::result<primitives::RuntimeDispatchInfo<primitives::Weight>>
   PaymentApiImpl::queryInfo(const primitives::Extrinsic &extrinsic,
                             uint32_t len,
                             OptionalHashRef at) const {

--- a/core/api/service/payment/impl/payment_api_impl.hpp
+++ b/core/api/service/payment/impl/payment_api_impl.hpp
@@ -24,7 +24,7 @@ namespace kagome::api {
                    std::shared_ptr<const blockchain::BlockTree> block_tree);
     ~PaymentApiImpl() override = default;
 
-    outcome::result<primitives::RuntimeDispatchInfo<primitives::OldWeight>>
+    outcome::result<primitives::RuntimeDispatchInfo<primitives::Weight>>
     queryInfo(const primitives::Extrinsic &extrinsic,
               uint32_t len,
               OptionalHashRef at) const override;

--- a/core/api/service/payment/payment_api.hpp
+++ b/core/api/service/payment/payment_api.hpp
@@ -22,8 +22,7 @@ namespace kagome::api {
 
     virtual ~PaymentApi() = default;
 
-    virtual outcome::result<
-        primitives::RuntimeDispatchInfo<primitives::Weight>>
+    virtual outcome::result<primitives::RuntimeDispatchInfo<primitives::Weight>>
     queryInfo(const primitives::Extrinsic &extrinsic,
               uint32_t len,
               OptionalHashRef at) const = 0;

--- a/core/api/service/payment/payment_api.hpp
+++ b/core/api/service/payment/payment_api.hpp
@@ -23,7 +23,7 @@ namespace kagome::api {
     virtual ~PaymentApi() = default;
 
     virtual outcome::result<
-        primitives::RuntimeDispatchInfo<primitives::OldWeight>>
+        primitives::RuntimeDispatchInfo<primitives::Weight>>
     queryInfo(const primitives::Extrinsic &extrinsic,
               uint32_t len,
               OptionalHashRef at) const = 0;

--- a/core/api/service/payment/requests/query_info.hpp
+++ b/core/api/service/payment/requests/query_info.hpp
@@ -17,27 +17,27 @@ namespace kagome::api::payment::request {
 
   class QueryInfo final
       : public details::RequestType<
-            primitives::RuntimeDispatchInfo<primitives::OldWeight>,
+            primitives::RuntimeDispatchInfo<primitives::Weight>,
             std::string,
-            std::string> {
+            std::optional<std::string>> {
    public:
     explicit QueryInfo(std::shared_ptr<PaymentApi> api) : api_(std::move(api)) {
       BOOST_ASSERT(api_);
-    };
+    }
 
-    outcome::result<primitives::RuntimeDispatchInfo<primitives::OldWeight>>
+    outcome::result<primitives::RuntimeDispatchInfo<primitives::Weight>>
     execute() override {
       auto ext_hex = getParam<0>();
       OUTCOME_TRY(ext_bytes, common::unhexWith0x(ext_hex));
 
       OUTCOME_TRY(extrinsic, scale::decode<primitives::Extrinsic>(ext_bytes));
 
-      auto at_hex = getParam<1>();
-      if (at_hex.empty()) {
+      auto at_hex_opt = getParam<1>();
+      if (not at_hex_opt.has_value()) {
         return api_->queryInfo(extrinsic, ext_bytes.size(), std::nullopt);
       }
       common::Hash256 at_hash;
-      OUTCOME_TRY(at, common::unhexWith0x(at_hex));
+      OUTCOME_TRY(at, common::unhexWith0x(at_hex_opt.value()));
       BOOST_ASSERT(at.size() == common::Hash256::size());
       std::copy_n(at.cbegin(), common::Hash256::size(), at_hash.begin());
       return api_->queryInfo(extrinsic, ext_bytes.size(), std::cref(at_hash));

--- a/core/api/transport/impl/ws/ws_session.cpp
+++ b/core/api/transport/impl/ws/ws_session.cpp
@@ -13,6 +13,7 @@
 #include <boost/beast/http/string_body.hpp>
 #include <boost/config.hpp>
 #include <libp2p/outcome/outcome.hpp>
+#include "log/logger.hpp"
 
 namespace boost::beast {
   template <class NextLayer, class DynamicBuffer>
@@ -138,6 +139,7 @@ namespace kagome::api {
   }
 
   void WsSession::respond(std::string_view response) {
+    SL_INFO(logger_, "Responding: {}", response);
     post([self{shared_from_this()}, response{std::string{response}}] {
       if (not self->is_ws_) {
         self->sessionClose();

--- a/core/api/transport/impl/ws/ws_session.cpp
+++ b/core/api/transport/impl/ws/ws_session.cpp
@@ -204,7 +204,7 @@ namespace kagome::api {
     sessionMake();
 
     asyncRead();
-  };
+  }
 
   void WsSession::onRead(boost::system::error_code ec,
                          std::size_t bytes_transferred) {

--- a/core/api/transport/impl/ws/ws_session.cpp
+++ b/core/api/transport/impl/ws/ws_session.cpp
@@ -12,8 +12,6 @@
 #include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/http/string_body.hpp>
 #include <boost/config.hpp>
-#include <libp2p/outcome/outcome.hpp>
-#include "log/logger.hpp"
 
 namespace boost::beast {
   template <class NextLayer, class DynamicBuffer>
@@ -139,7 +137,7 @@ namespace kagome::api {
   }
 
   void WsSession::respond(std::string_view response) {
-    SL_INFO(logger_, "Responding: {}", response);
+    SL_DEBUG(logger_, "Responding: {}", response);
     post([self{shared_from_this()}, response{std::string{response}}] {
       if (not self->is_ws_) {
         self->sessionClose();

--- a/core/api/transport/session.hpp
+++ b/core/api/transport/session.hpp
@@ -14,6 +14,7 @@
 #include <boost/signals2/signal.hpp>
 
 #include "api/transport/rpc_io_context.hpp"
+#include "log/logger.hpp"
 
 namespace kagome::api {
   enum struct SessionType {
@@ -69,6 +70,7 @@ namespace kagome::api {
      */
     void processRequest(std::string_view request,
                         std::shared_ptr<Session> session) {
+      SL_INFO(logger_, "Processing request: {}", request);
       on_request_(request, std::move(session));
     }
 
@@ -118,6 +120,7 @@ namespace kagome::api {
    private:
     std::function<OnRequestSignature> on_request_;  ///< `on request` callback
     OnCloseHandler on_close_;
+    log::Logger logger_ = log::createLogger("Session");
   };
 
 }  // namespace kagome::api

--- a/core/api/transport/session.hpp
+++ b/core/api/transport/session.hpp
@@ -70,7 +70,7 @@ namespace kagome::api {
      */
     void processRequest(std::string_view request,
                         std::shared_ptr<Session> session) {
-      SL_INFO(logger_, "Processing request: {}", request);
+      SL_DEBUG(logger_, "Processing request: {}", request);
       on_request_(request, std::move(session));
     }
 
@@ -120,7 +120,7 @@ namespace kagome::api {
    private:
     std::function<OnRequestSignature> on_request_;  ///< `on request` callback
     OnCloseHandler on_close_;
-    log::Logger logger_ = log::createLogger("Session");
+    log::Logger logger_ = log::createLogger("Session", "rpc_transport");
   };
 
 }  // namespace kagome::api

--- a/core/host_api/impl/offchain_extension.cpp
+++ b/core/host_api/impl/offchain_extension.cpp
@@ -110,10 +110,6 @@ namespace kagome::host_api {
       storage_type = StorageType::Persistent;
     } else if (kind == 2) {
       storage_type = StorageType::Local;
-    } else if (kind == 0) {
-      // TODO(xDimon): Remove this if-branch when it will be fixed it substrate
-      //  issue: https://github.com/soramitsu/kagome/issues/997
-      storage_type = StorageType::Persistent;
     } else {
       throw std::invalid_argument(
           "Method was called with unknown kind of storage");
@@ -137,10 +133,6 @@ namespace kagome::host_api {
       storage_type = StorageType::Persistent;
     } else if (kind == 2) {
       storage_type = StorageType::Local;
-    } else if (kind == 0) {
-      // TODO(xDimon): Remove this if-branch when it will be fixed it substrate
-      //  issue: https://github.com/soramitsu/kagome/issues/997
-      storage_type = StorageType::Persistent;
     } else {
       throw std::invalid_argument(
           "Method was called with unknown kind of storage");
@@ -166,10 +158,6 @@ namespace kagome::host_api {
       storage_type = StorageType::Persistent;
     } else if (kind == 2) {
       storage_type = StorageType::Local;
-    } else if (kind == 0) {
-      // TODO(xDimon): Remove this if-branch when it will be fixed it substrate
-      //  issue: https://github.com/soramitsu/kagome/issues/997
-      storage_type = StorageType::Persistent;
     } else {
       throw std::invalid_argument(
           "Method was called with unknown kind of storage");
@@ -208,10 +196,6 @@ namespace kagome::host_api {
       storage_type = StorageType::Persistent;
     } else if (kind == 2) {
       storage_type = StorageType::Local;
-    } else if (kind == 0) {
-      // TODO(xDimon): Remove this if-branch when it will be fixed it substrate
-      //  issue: https://github.com/soramitsu/kagome/issues/997
-      storage_type = StorageType::Persistent;
     } else {
       throw std::invalid_argument(
           "Method was called with unknown kind of storage");

--- a/core/offchain/types.hpp
+++ b/core/offchain/types.hpp
@@ -22,7 +22,12 @@ namespace kagome::offchain {
 
   using RandomSeed = common::Blob<32>;
 
-  enum class StorageType : int32_t { Undefined = 0, Persistent = 1, Local = 2 };
+  // https://github.com/paritytech/polkadot-sdk/blob/7ecf3f757a5d6f622309cea7f788e8a547a5dce8/substrate/primitives/core/src/offchain/mod.rs#L63
+  enum class StorageType : int32_t {
+    Undefined = 0,  // shouldn't be used
+    Persistent = 1,
+    Local = 2
+  };
 
   enum class HttpMethod { Undefined = 0, Get = 1, Post = 2 };
 
@@ -89,9 +94,9 @@ namespace kagome::offchain {
         : peer_id(std::move(peer_id)), address(std::move(address)) {}
 
     OpaqueNetworkState()
-        : peer_id(
-            libp2p::peer::PeerId::fromPublicKey(libp2p::crypto::ProtobufKey{{}})
-                .value()) {}
+        : peer_id(libp2p::peer::PeerId::fromPublicKey(
+                      libp2p::crypto::ProtobufKey{{}})
+                      .value()) {}
   };
 
   template <class Stream,

--- a/core/primitives/runtime_dispatch_info.hpp
+++ b/core/primitives/runtime_dispatch_info.hpp
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <scale/scale.hpp>
+#include <scale/tie.hpp>
+
 #include "common/unused.hpp"
 #include "scale/big_fixed_integers.hpp"
 
@@ -16,7 +18,9 @@ namespace kagome::primitives {
   using OldWeight = scale::Compact<uint64_t>;
 
   struct Weight {
+    // NOLINTBEGIN
     SCALE_TIE(2);
+    // NOLINTEND
     Weight() = default;
 
     explicit Weight(OldWeight w) : ref_time{w}, proof_size{0} {}
@@ -77,7 +81,7 @@ namespace kagome::primitives {
    */
   template <typename Weight>
   struct RuntimeDispatchInfo {
-    SCALE_TIE(3)
+    SCALE_TIE(3);  // NOLINT
 
     Weight weight;
     DispatchClass dispatch_class;

--- a/core/primitives/runtime_dispatch_info.hpp
+++ b/core/primitives/runtime_dispatch_info.hpp
@@ -58,7 +58,6 @@ namespace kagome::primitives {
   template <typename Stream,
             typename = std::enable_if_t<Stream::is_decoder_stream>>
   Stream &operator>>(Stream &stream, DispatchClass &dispatch_class) {
-    std::ignore = stream.nextByte();
     uint8_t dispatch_class_byte;
     stream >> dispatch_class_byte;
     dispatch_class = static_cast<DispatchClass>(dispatch_class_byte);

--- a/core/primitives/runtime_dispatch_info.hpp
+++ b/core/primitives/runtime_dispatch_info.hpp
@@ -28,6 +28,10 @@ namespace kagome::primitives {
     scale::Compact<uint64_t> ref_time;
     // The weight of storage space used by proof of validity.
     scale::Compact<uint64_t> proof_size;
+
+    bool operator==(const Weight &other) const {
+      return ref_time == other.ref_time && proof_size == other.proof_size;
+    }
   };
 
   // for some reason encoded as variant in substrate, thus custom encode/decode
@@ -87,6 +91,11 @@ namespace kagome::primitives {
      * `SignedExtension`).
      */
     Balance partial_fee;
+
+    bool operator==(const RuntimeDispatchInfo &other) const {
+      return weight == other.weight && dispatch_class == other.dispatch_class
+          && partial_fee == other.partial_fee;
+    }
   };
 
 }  // namespace kagome::primitives

--- a/core/primitives/runtime_dispatch_info.hpp
+++ b/core/primitives/runtime_dispatch_info.hpp
@@ -28,10 +28,6 @@ namespace kagome::primitives {
     scale::Compact<uint64_t> ref_time;
     // The weight of storage space used by proof of validity.
     scale::Compact<uint64_t> proof_size;
-
-    bool operator==(const Weight &other) const {
-      return ref_time == other.ref_time && proof_size == other.proof_size;
-    }
   };
 
   // for some reason encoded as variant in substrate, thus custom encode/decode
@@ -91,11 +87,6 @@ namespace kagome::primitives {
      * `SignedExtension`).
      */
     Balance partial_fee;
-
-    bool operator==(const RuntimeDispatchInfo &other) const {
-      return weight == other.weight && dispatch_class == other.dispatch_class
-          && partial_fee == other.partial_fee;
-    }
   };
 
 }  // namespace kagome::primitives

--- a/core/primitives/runtime_dispatch_info.hpp
+++ b/core/primitives/runtime_dispatch_info.hpp
@@ -71,7 +71,7 @@ namespace kagome::primitives {
   template <typename Stream,
             typename = std::enable_if_t<Stream::is_decoder_stream>>
   Stream &operator<<(Stream &stream, DispatchClass dispatch_class) {
-    return stream << uint8_t{0} << dispatch_class;
+    return stream << dispatch_class;
   }
 
   struct Balance : public scale::Fixed<scale::uint128_t> {};

--- a/core/runtime/runtime_api/impl/transaction_payment_api.cpp
+++ b/core/runtime/runtime_api/impl/transaction_payment_api.cpp
@@ -16,7 +16,7 @@ OUTCOME_CPP_DEFINE_CATEGORY(kagome::runtime,
   switch (err) {
     case E::TRANSACTION_PAYMENT_API_NOT_FOUND:
       return "Transaction payment runtime API is not found in the runtime";
-    case TransactionPaymentApiImpl::Error::API_BELOW_VERSION_2_NOT_SUPPORTED:
+    case E::API_BELOW_VERSION_2_NOT_SUPPORTED:
       return "API below version 2 is not supported";
   }
   return "Unknown TransactionPaymentApiImpl error";

--- a/core/runtime/runtime_api/impl/transaction_payment_api.hpp
+++ b/core/runtime/runtime_api/impl/transaction_payment_api.hpp
@@ -19,13 +19,15 @@ namespace kagome::runtime {
     enum class Error {
       // Transaction payment runtime API is not found in the runtime
       TRANSACTION_PAYMENT_API_NOT_FOUND = 1,
+      // API below version 2 is not supported (needed for query_info)
+      API_BELOW_VERSION_2_NOT_SUPPORTED = 2,
     };
 
     explicit TransactionPaymentApiImpl(std::shared_ptr<Executor> executor,
                                        std::shared_ptr<Core> core_api,
                                        std::shared_ptr<crypto::Hasher> hasher);
 
-    outcome::result<primitives::RuntimeDispatchInfo<primitives::OldWeight>>
+    outcome::result<primitives::RuntimeDispatchInfo<primitives::Weight>>
     query_info(const primitives::BlockHash &block,
                const primitives::Extrinsic &ext,
                uint32_t len) override;

--- a/core/runtime/runtime_api/transaction_payment_api.hpp
+++ b/core/runtime/runtime_api/transaction_payment_api.hpp
@@ -18,7 +18,7 @@ namespace kagome::runtime {
     virtual ~TransactionPaymentApi() = default;
 
     virtual outcome::result<
-        primitives::RuntimeDispatchInfo<primitives::OldWeight>>
+        primitives::RuntimeDispatchInfo<primitives::Weight>>
     query_info(const primitives::BlockHash &block,
                const primitives::Extrinsic &ext,
                uint32_t len) = 0;

--- a/housekeeping/docker/kagome-dev/minideb.Dockerfile
+++ b/housekeeping/docker/kagome-dev/minideb.Dockerfile
@@ -62,8 +62,7 @@ ENV KAGOME_PACKAGE_VERSION=${KAGOME_PACKAGE_VERSION}
 
 RUN --mount=type=secret,id=google_creds,target=/root/.gcp/google_creds.json \
       install_packages \
-        kagome-dev=${KAGOME_PACKAGE_VERSION}  \
-        kagome-dev-runtime && \
+        kagome-dev=${KAGOME_PACKAGE_VERSION} && \
         sed -i '1s/^/#/' /etc/apt/sources.list.d/kagome.list
 
 CMD ["/usr/bin/tini", "--", "/bin/bash", "-c"]

--- a/test/core/api/service/payment/payment_api_test.cpp
+++ b/test/core/api/service/payment/payment_api_test.cpp
@@ -20,8 +20,8 @@ using kagome::common::Buffer;
 using kagome::common::BufferView;
 using kagome::primitives::BlockInfo;
 using kagome::primitives::Extrinsic;
-using kagome::primitives::OldWeight;
 using kagome::primitives::RuntimeDispatchInfo;
+using kagome::primitives::Weight;
 using kagome::runtime::TransactionPaymentApiMock;
 
 using testing::_;
@@ -54,7 +54,7 @@ TEST_F(PaymentApiTest, QueryInfo) {
   auto len = 22u;
   auto deepest_hash = "12345"_hash256;
   BlockInfo best_leaf{10, deepest_hash};
-  RuntimeDispatchInfo<OldWeight> expected_result;
+  RuntimeDispatchInfo<Weight> expected_result;
 
   EXPECT_CALL(*block_tree_, bestBlock()).WillOnce(Return(best_leaf));
   EXPECT_CALL(*transaction_payment_api_,
@@ -67,43 +67,24 @@ TEST_F(PaymentApiTest, QueryInfo) {
 }
 
 TEST_F(PaymentApiTest, DecodeRuntimeDispatchInfo) {
-  // for extrinsic 0x280403000b30e7f2b98501
-  //  weight: 133,706,000
-  //  class: Mandatory
-  //  partialFee: 0
-  //
   // clang-format off
-  unsigned char data[22] = {
-    0x42, 0xc4, 0xe0, 0x1f,
-    0x00, 0x02, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00};
+  // for extrinsic 0x350284007ef99ee767314ccb4726be579ab3eabd212741b3796db40405ff421c47b0ae8502268965ca1a619e1aec211193906ff60009a2d6b29d61e1f46c4eb6e1646235e0217450f2c129fe9a3adc3d5f585fadab592a5602496f635c3718bc753e9e9f221b550200000105000018c7f5a8530d6aafc1b191156294a9e27bb674128607896f3fd5914282fb196d00
+  //  weight:
+  //    {
+  //      ref_time: 144,460,000
+  //      proof_size: 3593
+  //     }
+  //  class: normal
+  //  partialFee: 154146098
+  //
   // clang-format on
+  Buffer data =
+      Buffer::fromHex("8223712225380032153009000000000000000000000000").value();
 
-  auto info = scale::decode<RuntimeDispatchInfo<OldWeight>>(data).value();
+  auto info = scale::decode<RuntimeDispatchInfo<Weight>>(data).value();
 
-  ASSERT_EQ(*info.weight, 133706000);
-  ASSERT_EQ(info.dispatch_class, kagome::primitives::DispatchClass::Mandatory);
-  ASSERT_EQ(*info.partial_fee, 0);
-}
-
-// 0x410284000a0e6dfd6e3b14d5f6a379ccb79e4e547c9bb8f0f2793e32528c45eecef15a3b01e4421d5f63c82b99ef6c1d4295e80f7b2ffdbf787d25ea093eff633d231bfe77776a7105600d528c0ba77a44de88916681815d695b7a72dd59235359a924df835503000005000040139d1483af62a1ad4144815f418640fdebafabf2bc922083614fff77c976170700b24f980b
-// {
-//  weight: 143,322,000
-//  class: Normal
-//  partialFee: 15.7681 mDOT (157681946)
-// }
-TEST_F(PaymentApiTest, DecodeRuntimeDispatchInfoWithFee) {
-  const uint8_t data[]{
-      0x42, 0xae, 0x2b, 0x22, 0x00, 0x00, 0x1a, 0x09, 0x66, 0x09, 0x00,
-      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  };
-
-  auto info = scale::decode<RuntimeDispatchInfo<OldWeight>>(data).value();
-
-  ASSERT_EQ(*info.weight, 143322000);
+  ASSERT_EQ(*info.weight.ref_time, 144460000);
+  ASSERT_EQ(*info.weight.proof_size, 3593);
   ASSERT_EQ(info.dispatch_class, kagome::primitives::DispatchClass::Normal);
-  ASSERT_EQ(*info.partial_fee, 157681946);
+  ASSERT_EQ(*info.partial_fee, 154146098);
 }

--- a/test/core/host_api/offchain_extension_test.cpp
+++ b/test/core/host_api/offchain_extension_test.cpp
@@ -290,7 +290,7 @@ TEST_P(TernaryParametrizedTest, LocalStorageGet) {
 
 INSTANTIATE_TEST_SUITE_P(Instance,
                          TernaryParametrizedTest,
-                         testing::Values(0, 1, 2));
+                         testing::Values(1, 2));
 
 /**
  * @given method, uri, meta

--- a/test/mock/core/runtime/transaction_payment_api_mock.hpp
+++ b/test/mock/core/runtime/transaction_payment_api_mock.hpp
@@ -15,7 +15,7 @@ namespace kagome::runtime {
   class TransactionPaymentApiMock : public TransactionPaymentApi {
    public:
     MOCK_METHOD(
-        outcome::result<primitives::RuntimeDispatchInfo<primitives::OldWeight>>,
+        outcome::result<primitives::RuntimeDispatchInfo<primitives::Weight>>,
         query_info,
         (const primitives::BlockHash &block,
          const primitives::Extrinsic &ext,


### PR DESCRIPTION
[//]: # (
Copyright Quadrivium LLC
All Rights Reserved
SPDX-License-Identifier: Apache-2.0
)

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch. -->

### Referenced issues

Closes #2183 

### Description of the Change

Fixes payment_queryInfo, for compatibility with e.g. Nova wallet

### Possible Drawbacks

Older versions of query_info runtime api is now obsolete

## Checklist Before Opening a PR

Before you open a Pull Request (PR), please make sure you've completed the following steps and confirm by answering 'Yes' to each item:

1. **Code is formatted**: Have you run your code through clang-format to ensure it adheres to the project's coding standards? **Yes**
2. **Code is documented**: Have you added comments and documentation to your code according to the guidelines in the project's [contributing guidelines](https://github.com/qdrvm/kagome/CONTRIBUTING.md)? **Yes**
3. **Self-review**: Have you reviewed your own code to ensure it is free of typos, syntax errors, logical errors, and unresolved TODOs or FIXME without linking to an issue? **Yes**
4. **Zombienet Tests**: Have you ensured that the zombienet tests are passing? Zombienet is a network simulation and testing tool used in this project. It's important to ensure that these tests pass to maintain the stability and reliability of the project. **No (not needed as this is RPC related PR)**

<!-- Please answer 'Yes' to each of these items in your PR description to confirm that you've completed them. This will help maintain the quality of the project and facilitate efficient collaboration. -->

