### PR TITLE
Add processing of 0 kind of offchain storage

### DIFF
--- a/core/host_api/impl/offchain_extension.cpp
+++ b/core/host_api/impl/offchain_extension.cpp
@@ -106,7 +106,8 @@ namespace kagome::host_api {
     auto &memory = memory_provider_->getCurrentMemory()->get();
 
     StorageType storage_type = StorageType::Undefined;
-    if (kind == 1) {
+    if (kind == 1 || kind == 0) {  // 0 is needed due to the bug in the runtime
+                                   // that sends 0 instead of 1
       storage_type = StorageType::Persistent;
     } else if (kind == 2) {
       storage_type = StorageType::Local;
@@ -129,7 +130,8 @@ namespace kagome::host_api {
     auto &memory = memory_provider_->getCurrentMemory()->get();
 
     StorageType storage_type = StorageType::Undefined;
-    if (kind == 1) {
+    if (kind == 1 || kind == 0) {  // 0 is needed due to the bug in the runtime
+                                   // that sends 0 instead of 1
       storage_type = StorageType::Persistent;
     } else if (kind == 2) {
       storage_type = StorageType::Local;
@@ -154,7 +156,8 @@ namespace kagome::host_api {
     auto &memory = memory_provider_->getCurrentMemory()->get();
 
     StorageType storage_type = StorageType::Undefined;
-    if (kind == 1) {
+    if (kind == 1 || kind == 0) {  // 0 is needed due to the bug in the runtime
+                                   // that sends 0 instead of 1
       storage_type = StorageType::Persistent;
     } else if (kind == 2) {
       storage_type = StorageType::Local;
@@ -192,7 +195,8 @@ namespace kagome::host_api {
     auto &memory = memory_provider_->getCurrentMemory()->get();
 
     StorageType storage_type = StorageType::Undefined;
-    if (kind == 1) {
+    if (kind == 1 || kind == 0) {  // 0 is needed due to the bug in the runtime
+                                   // that sends 0 instead of 1
       storage_type = StorageType::Persistent;
     } else if (kind == 2) {
       storage_type = StorageType::Local;


### PR DESCRIPTION
[//]: # (
Copyright Quadrivium LLC
All Rights Reserved
SPDX-License-Identifier: Apache-2.0
)

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch. -->

### Referenced issues

None

### Description of the Change

It turns out https://github.com/qdrvm/kagome/blob/c1c957515c7bbe91bd23c68f1ec7e5dff8b7eed1/core/host_api/impl/offchain_extension.cpp#L192-L193 can actually receive 0 as a storage kind. 
This is probably a bug from the runtime. So we should treat this as Persistent storage as it was checked that in Polkadot-SDK the same host api always receives persistent storage kind.
Without this fix KAGOME throws an error

### Possible Drawbacks

A bit dirty(

## Checklist Before Opening a PR

Before you open a Pull Request (PR), please make sure you've completed the following steps and confirm by answering 'Yes' to each item:

1. **Code is formatted**: Have you run your code through clang-format to ensure it adheres to the project's coding standards? **Yes**
2. **Code is documented**: Have you added comments and documentation to your code according to the guidelines in the project's [contributing guidelines](https://github.com/qdrvm/kagome/CONTRIBUTING.md)? **Yes**
3. **Self-review**: Have you reviewed your own code to ensure it is free of typos, syntax errors, logical errors, and unresolved TODOs or FIXME without linking to an issue? **Yes**
4. **Zombienet Tests**: Have you ensured that the zombienet tests are passing? Zombienet is a network simulation and testing tool used in this project. It's important to ensure that these tests pass to maintain the stability and reliability of the project. **Yes**

<!-- Please answer 'Yes' to each of these items in your PR description to confirm that you've completed them. This will help maintain the quality of the project and facilitate efficient collaboration. -->

