### PR TITLE
unbuffered subprocess

### DIFF
--- a/core/parachain/pvf/workers.cpp
+++ b/core/parachain/pvf/workers.cpp
@@ -27,9 +27,9 @@ namespace kagome::parachain {
 
   struct ProcessAndPipes : std::enable_shared_from_this<ProcessAndPipes> {
     AsyncPipe pipe_stdin;
-    boost::asio::buffered_write_stream<AsyncPipe &> writer;
+    AsyncPipe &writer;
     AsyncPipe pipe_stdout;
-    boost::asio::buffered_read_stream<AsyncPipe &> reader;
+    AsyncPipe &reader;
     boost::process::child process;
     std::shared_ptr<Buffer> writing = std::make_shared<Buffer>();
     std::shared_ptr<Buffer> reading = std::make_shared<Buffer>();
@@ -66,13 +66,7 @@ namespace kagome::parachain {
                   if (ec) {
                     return cb(ec);
                   }
-                  self->writer.async_flush(
-                      [cb](boost::system::error_code ec, size_t) mutable {
-                        if (ec) {
-                          return cb(ec);
-                        }
-                        cb(outcome::success());
-                      });
+                  cb(outcome::success());
                 });
           });
     }

--- a/core/parachain/pvf/workers.cpp
+++ b/core/parachain/pvf/workers.cpp
@@ -27,8 +27,10 @@ namespace kagome::parachain {
 
   struct ProcessAndPipes : std::enable_shared_from_this<ProcessAndPipes> {
     AsyncPipe pipe_stdin;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
     AsyncPipe &writer;
     AsyncPipe pipe_stdout;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
     AsyncPipe &reader;
     boost::process::child process;
     std::shared_ptr<Buffer> writing = std::make_shared<Buffer>();


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- try disable `boost::asio::buffered_write_stream`/`boost::asio::buffered_read_stream` which seem to corrupt memory

### Possible Drawbacks