### PR TITLE
Reduce candidates storing time

### DIFF
--- a/core/parachain/availability/store/store_impl.cpp
+++ b/core/parachain/availability/store/store_impl.cpp
@@ -18,7 +18,6 @@ namespace kagome::parachain {
         storage_{std::move(storage)},
         chain_sub_{std::move(chain_sub_engine)} {
     BOOST_ASSERT(storage_ != nullptr);
-    BOOST_ASSERT(chain_sub_ != nullptr);
 
     chain_sub_.onDeactivate(
         [this](

--- a/core/parachain/availability/store/store_impl.cpp
+++ b/core/parachain/availability/store/store_impl.cpp
@@ -23,8 +23,6 @@ namespace kagome::parachain {
     chain_sub_.onDeactivate(
         [this](
             const primitives::events::RemoveAfterFinalizationParams &params) {
-          SL_INFO(
-              logger, "Deactivate after finalization of {}", params.finalized);
           if (params.removed.empty()) {
             return;
           }

--- a/core/parachain/availability/store/store_impl.cpp
+++ b/core/parachain/availability/store/store_impl.cpp
@@ -6,7 +6,7 @@
 
 #include "parachain/availability/store/store_impl.hpp"
 
-constexpr uint64_t KEEP_CANDIDATES_TIMEOUT = 10 * 60;
+constexpr uint64_t KEEP_CANDIDATES_TIMEOUT = 1 * 60;
 
 namespace kagome::parachain {
   AvailabilityStoreImpl::AvailabilityStoreImpl(clock::SteadyClock &steady_clock)

--- a/core/parachain/availability/store/store_impl.hpp
+++ b/core/parachain/availability/store/store_impl.hpp
@@ -10,19 +10,25 @@
 
 #include <unordered_map>
 #include <unordered_set>
+#include "application/app_state_manager.hpp"
 #include "log/logger.hpp"
 #include "primitives/event_types.hpp"
 #include "storage/spaced_storage.hpp"
 #include "utils/safe_object.hpp"
 
 namespace kagome::parachain {
-  class AvailabilityStoreImpl : public AvailabilityStore {
+  class AvailabilityStoreImpl
+      : public AvailabilityStore,
+        public std::enable_shared_from_this<AvailabilityStoreImpl> {
    public:
     AvailabilityStoreImpl(
+        std::shared_ptr<application::AppStateManager> app_state_manager,
         clock::SteadyClock &steady_clock,
         std::shared_ptr<storage::SpacedStorage> storage,
         primitives::events::ChainSubscriptionEnginePtr chain_sub_engine);
     ~AvailabilityStoreImpl() override = default;
+
+    bool start();
 
     bool hasChunk(const CandidateHash &candidate_hash,
                   ValidatorIndex index) const override;
@@ -67,8 +73,8 @@ namespace kagome::parachain {
 
     log::Logger logger = log::createLogger("AvailabilityStore", "parachain");
     clock::SteadyClock &steady_clock_;
-    SafeObject<State> state_{};
     std::shared_ptr<storage::SpacedStorage> storage_;
     primitives::events::ChainSub chain_sub_;
+    SafeObject<State> state_{};
   };
 }  // namespace kagome::parachain

--- a/core/parachain/availability/store/store_impl.hpp
+++ b/core/parachain/availability/store/store_impl.hpp
@@ -11,13 +11,17 @@
 #include <unordered_map>
 #include <unordered_set>
 #include "log/logger.hpp"
+#include "primitives/event_types.hpp"
 #include "storage/spaced_storage.hpp"
 #include "utils/safe_object.hpp"
+
 namespace kagome::parachain {
   class AvailabilityStoreImpl : public AvailabilityStore {
    public:
-    AvailabilityStoreImpl(clock::SteadyClock &steady_clock,
-                          std::shared_ptr<storage::SpacedStorage> storage);
+    AvailabilityStoreImpl(
+        clock::SteadyClock &steady_clock,
+        std::shared_ptr<storage::SpacedStorage> storage,
+        primitives::events::ChainSubscriptionEnginePtr chain_sub_engine);
     ~AvailabilityStoreImpl() override = default;
 
     bool hasChunk(const CandidateHash &candidate_hash,
@@ -65,5 +69,6 @@ namespace kagome::parachain {
     clock::SteadyClock &steady_clock_;
     SafeObject<State> state_{};
     std::shared_ptr<storage::SpacedStorage> storage_;
+    primitives::events::ChainSub chain_sub_;
   };
 }  // namespace kagome::parachain


### PR DESCRIPTION
[//]: # (
Copyright Quadrivium LLC
All Rights Reserved
SPDX-License-Identifier: Apache-2.0
)

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch. -->

### Referenced issues

Closes #2276 

### Description of the Change

Storing candidates in availability store might lead to OOM in Kusama. This PR attempts reducing timeout for storing candidates improves situation.
In addition candidates will be removed whenever corresponding relay chain blocks are finalized.
It is safe to keep candidates for shorter period as after merging #2271 we are going to store them in db for 25 hours anyway

### Possible Drawbacks

None

## Checklist Before Opening a PR

Before you open a Pull Request (PR), please make sure you've completed the following steps and confirm by answering 'Yes' to each item:

1. **Code is formatted**: Have you run your code through clang-format to ensure it adheres to the project's coding standards? **Yes**
2. **Code is documented**: Have you added comments and documentation to your code according to the guidelines in the project's [contributing guidelines](https://github.com/qdrvm/kagome/CONTRIBUTING.md)? **Yes**
3. **Self-review**: Have you reviewed your own code to ensure it is free of typos, syntax errors, logical errors, and unresolved TODOs or FIXME without linking to an issue? **Yes**
4. **Zombienet Tests**: Have you ensured that the zombienet tests are passing? Zombienet is a network simulation and testing tool used in this project. It's important to ensure that these tests pass to maintain the stability and reliability of the project. **Not yet**

<!-- Please answer 'Yes' to each of these items in your PR description to confirm that you've completed them. This will help maintain the quality of the project and facilitate efficient collaboration. -->

