### PR TITLE
Return error when runtime code not found

### DIFF
--- a/core/parachain/pvf/module_precompiler.cpp
+++ b/core/parachain/pvf/module_precompiler.cpp
@@ -169,7 +169,7 @@ namespace kagome::parachain {
               "No validation code found for parachain {} with 'included' "
               "occupied assumption",
               para_id);
-      return outcome::success();
+      return outcome::failure(runtime::RuntimeExecutionError::RUNTIME_CODE_NOT_FOUND);
     }
     auto &code = *code_opt;
     auto hash = hasher_->blake2b_256(code);

--- a/core/runtime/common/runtime_execution_error.cpp
+++ b/core/runtime/common/runtime_execution_error.cpp
@@ -12,6 +12,8 @@ OUTCOME_CPP_DEFINE_CATEGORY(kagome::runtime, RuntimeExecutionError, e) {
       return "No storage transactions were started";
     case E::EXPORT_FUNCTION_NOT_FOUND:
       return "Export function not found";
+    case E::RUNTIME_CODE_NOT_FOUND:
+      return "Runtime code not found";
   }
   return "Unknown RuntimeExecutionError";
 }

--- a/core/runtime/common/runtime_execution_error.hpp
+++ b/core/runtime/common/runtime_execution_error.hpp
@@ -15,7 +15,8 @@ namespace kagome::runtime {
    */
   enum class RuntimeExecutionError : uint8_t {  // 0 is reserved for success
     NO_TRANSACTIONS_WERE_STARTED = 1,
-    EXPORT_FUNCTION_NOT_FOUND
+    EXPORT_FUNCTION_NOT_FOUND,
+    RUNTIME_CODE_NOT_FOUND
   };
 }  // namespace kagome::runtime
 


### PR DESCRIPTION
[//]: # (
Copyright Quadrivium LLC
All Rights Reserved
SPDX-License-Identifier: Apache-2.0
)

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch. -->

### Referenced issues

Closes #2280

### Description of the Change

Returning success in `precompileModulesForCore` when in fact no runtime was found can lead to crash at the launch of validating node

### Possible Drawbacks

Not clear yet why we couldn't find runtime

## Checklist Before Opening a PR

Before you open a Pull Request (PR), please make sure you've completed the following steps and confirm by answering 'Yes' to each item:

1. **Code is formatted**: Have you run your code through clang-format to ensure it adheres to the project's coding standards? **[Yes|No]**
2. **Code is documented**: Have you added comments and documentation to your code according to the guidelines in the project's [contributing guidelines](https://github.com/qdrvm/kagome/CONTRIBUTING.md)? **[Yes|No]**
3. **Self-review**: Have you reviewed your own code to ensure it is free of typos, syntax errors, logical errors, and unresolved TODOs or FIXME without linking to an issue? **[Yes|No]**
4. **Zombienet Tests**: Have you ensured that the zombienet tests are passing? Zombienet is a network simulation and testing tool used in this project. It's important to ensure that these tests pass to maintain the stability and reliability of the project. **[Yes|No]**

<!-- Please answer 'Yes' to each of these items in your PR description to confirm that you've completed them. This will help maintain the quality of the project and facilitate efficient collaboration. -->

