### PR TITLE
fix grandpa equivocation

### DIFF
--- a/core/consensus/grandpa/impl/environment_impl.cpp
+++ b/core/consensus/grandpa/impl/environment_impl.cpp
@@ -501,7 +501,7 @@ namespace kagome::consensus::grandpa {
       SL_WARN(logger_,
               "Round #{}: can't submit equivocation report: {}",
               equivocation.round(),
-              key_owner_proof_res.error());
+              submit_res.error());
       return submit_res.as_failure();
     }
 

--- a/core/consensus/grandpa/types/equivocation_proof.hpp
+++ b/core/consensus/grandpa/types/equivocation_proof.hpp
@@ -61,8 +61,10 @@ namespace kagome::consensus::grandpa {
     friend scale::ScaleEncoderStream &operator<<(
         scale::ScaleEncoderStream &s, const Equivocation &equivocation) {
       return s << equivocation.stage << equivocation.round_number
-               << equivocation.first.id << equivocation.first
-               << equivocation.second;
+               << equivocation.first.id << equivocation.first.getBlockInfo()
+               << equivocation.first.signature
+               << equivocation.second.getBlockInfo()
+               << equivocation.second.signature;
     }
   };
 

--- a/core/consensus/grandpa/vote_types.hpp
+++ b/core/consensus/grandpa/vote_types.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace kagome::consensus::grandpa {
-  enum class VoteType { Prevote, Precommit };
+  enum class VoteType : uint8_t { Prevote, Precommit };
 }


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- fix encoding
- fix `.error()` from wrong variable

### Possible Drawbacks
