### PR TITLE
fix approval stop future

### DIFF
--- a/core/parachain/approval/approval_distribution.cpp
+++ b/core/parachain/approval/approval_distribution.cpp
@@ -3402,7 +3402,11 @@ namespace kagome::parachain {
           libp2p::SharedFn{[&, promise{std::move(promise)}]() mutable {
             promise.set_value(approvedAncestor(min, max));
           }});
-      return future.get();
+      try {
+        return future.get();
+      } catch (std::future_error &) {
+        return block_tree_->getLastFinalized();
+      }
     }
 
     if (max.number <= min.number) {


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- `stop` was called, so thread pool ignored callback along with `promise`, causing exception on `get`.

### Possible Drawbacks