### PR TITLE
Audi store

### DIFF
--- a/core/authority_discovery/CMakeLists.txt
+++ b/core/authority_discovery/CMakeLists.txt
@@ -9,9 +9,12 @@ add_subdirectory(protobuf)
 add_library(address_publisher
     publisher/address_publisher.cpp
     query/query_impl.cpp
-    )
+    query/audi_store_impl.cpp
+    query/audi_store_impl.hpp
+)
 target_link_libraries(address_publisher
     authority_discovery_proto
     logger
+    scale_libp2p_types
     sha
-    )
+)

--- a/core/authority_discovery/query/audi_store.hpp
+++ b/core/authority_discovery/query/audi_store.hpp
@@ -42,7 +42,8 @@ namespace kagome::authority_discovery {
      * Remove authority discovery data
      * @param authority the authority to remove
      */
-    virtual outcome::result<void> remove(const primitives::AuthorityDiscoveryId &authority) = 0;
+    virtual outcome::result<void> remove(
+        const primitives::AuthorityDiscoveryId &authority) = 0;
 
     /**
      * Check if the store contains the authority
@@ -52,10 +53,16 @@ namespace kagome::authority_discovery {
     virtual bool contains(
         const primitives::AuthorityDiscoveryId &authority) const = 0;
 
+    /**
+     * Apply a function to each entry in the store
+     */
     virtual void forEach(
         std::function<void(const primitives::AuthorityDiscoveryId &,
                            const AuthorityPeerInfo &)> f) const = 0;
 
+    /**
+     * Retain only the entries that satisfy the predicate
+     */
     virtual void retainIf(
         std::function<bool(const primitives::AuthorityDiscoveryId &,
                            const AuthorityPeerInfo &)> f) = 0;

--- a/core/authority_discovery/query/audi_store.hpp
+++ b/core/authority_discovery/query/audi_store.hpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <libp2p/peer/peer_info.hpp>
+
+#include "authority_discovery/query/authority_peer_info.hpp"
+#include "common/buffer.hpp"
+#include "primitives/authority_discovery_id.hpp"
+#include "storage/face/map_cursor.hpp"
+
+namespace kagome::authority_discovery {
+
+  /**
+   * Interface for storing and retrieving authority discovery data
+   */
+  class AudiStore {
+   public:
+    virtual ~AudiStore() = default;
+
+    /**
+     * Store authority discovery data
+     * @param authority the authority to store
+     * @param data the data to store
+     */
+    virtual void store(const primitives::AuthorityDiscoveryId &authority,
+                       const AuthorityPeerInfo &data) = 0;
+
+    /**
+     * Get authority discovery data
+     * @param authority the authority to get
+     * @return the data if it exists, otherwise std::nullopt
+     */
+    virtual std::optional<AuthorityPeerInfo> get(
+        const primitives::AuthorityDiscoveryId &authority) const = 0;
+
+    /**
+     * Remove authority discovery data
+     * @param authority the authority to remove
+     * @return true if the authority was removed, false if it didn't exist
+     */
+    virtual bool remove(const primitives::AuthorityDiscoveryId &authority) = 0;
+
+    /**
+     * Check if the store contains the authority
+     * @param authority the authority to check
+     * @return true if the authority is in the store, false otherwise
+     */
+    virtual bool contains(
+        const primitives::AuthorityDiscoveryId &authority) const = 0;
+
+    virtual void forEach(
+        std::function<void(const primitives::AuthorityDiscoveryId &,
+                           const AuthorityPeerInfo &)> f) const = 0;
+  };
+
+}  // namespace kagome::authority_discovery

--- a/core/authority_discovery/query/audi_store.hpp
+++ b/core/authority_discovery/query/audi_store.hpp
@@ -41,9 +41,8 @@ namespace kagome::authority_discovery {
     /**
      * Remove authority discovery data
      * @param authority the authority to remove
-     * @return true if the authority was removed, false if it didn't exist
      */
-    virtual bool remove(const primitives::AuthorityDiscoveryId &authority) = 0;
+    virtual outcome::result<void> remove(const primitives::AuthorityDiscoveryId &authority) = 0;
 
     /**
      * Check if the store contains the authority
@@ -56,6 +55,10 @@ namespace kagome::authority_discovery {
     virtual void forEach(
         std::function<void(const primitives::AuthorityDiscoveryId &,
                            const AuthorityPeerInfo &)> f) const = 0;
+
+    virtual void retainIf(
+        std::function<bool(const primitives::AuthorityDiscoveryId &,
+                           const AuthorityPeerInfo &)> f) = 0;
   };
 
 }  // namespace kagome::authority_discovery

--- a/core/authority_discovery/query/audi_store_impl.cpp
+++ b/core/authority_discovery/query/audi_store_impl.cpp
@@ -81,6 +81,7 @@ namespace kagome::authority_discovery {
       std::function<void(const primitives::AuthorityDiscoveryId &,
                          const AuthorityPeerInfo &)> f) const {
     auto cursor = space_->cursor();
+    std::ignore = cursor->seekFirst();
     while (cursor->isValid()) {
       auto key = cursor->key();
       auto value = cursor->value();

--- a/core/authority_discovery/query/audi_store_impl.cpp
+++ b/core/authority_discovery/query/audi_store_impl.cpp
@@ -74,7 +74,7 @@ namespace kagome::authority_discovery {
   bool AudiStoreImpl::contains(
       const primitives::AuthorityDiscoveryId &authority) const {
     auto res = space_->tryGet(authority);
-    return res.has_value() ? res.value().has_value() : false;
+    return res.has_value() and res.value().has_value();
   }
 
   void AudiStoreImpl::forEach(

--- a/core/authority_discovery/query/audi_store_impl.cpp
+++ b/core/authority_discovery/query/audi_store_impl.cpp
@@ -1,0 +1,104 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "authority_discovery/query/audi_store_impl.hpp"
+
+#include <scale/kagome_scale.hpp>
+
+namespace kagome::authority_discovery {
+
+  AudiStoreImpl::AudiStoreImpl(std::shared_ptr<storage::SpacedStorage> storage)
+      : space_{storage->getSpace(storage::Space::kAudiPeers)} {
+    BOOST_ASSERT(space_ != nullptr);
+  }
+
+  void AudiStoreImpl::store(const primitives::AuthorityDiscoveryId &authority,
+                            const AuthorityPeerInfo &data) {
+    auto encoded = scale::encode(data);
+
+    if (not encoded) {
+      SL_ERROR(log_, "Failed to encode PeerInfo");
+      return;
+    }
+
+    if (auto res = space_->put(authority, common::Buffer(encoded.value()));
+        not res) {
+      SL_ERROR(
+          log_, "Failed to put authority {} error {}", authority, res.error());
+    }
+  }
+
+  std::optional<AuthorityPeerInfo> AudiStoreImpl::get(
+      const primitives::AuthorityDiscoveryId &authority) const {
+    auto res = space_->tryGet(authority);
+
+    // check if there was any critical error during reading
+    if (not res) {
+      SL_CRITICAL(log_,
+                  "Failed to get authority {} due to database error {}",
+                  authority,
+                  res.error());
+      return std::nullopt;
+    }
+
+    // check if the authority was not found
+    if (not res.value()) {
+      return std::nullopt;
+    }
+
+    auto decoded = scale::decode<AuthorityPeerInfo>(res.value().value());
+
+    if (not decoded) {
+      SL_ERROR(log_, "Failed to decode PeerInfo");
+      return std::nullopt;
+    }
+
+    return decoded.value();
+  }
+
+  bool AudiStoreImpl::remove(
+      const primitives::AuthorityDiscoveryId &authority) {
+    if (auto res = space_->remove(authority); not res) {
+      SL_ERROR(log_,
+               "Failed to remove authority {} error {}",
+               authority,
+               res.error());
+      return false;
+    }
+    return true;
+  }
+
+  bool AudiStoreImpl::contains(
+      const primitives::AuthorityDiscoveryId &authority) const {
+    auto res = space_->tryGet(authority);
+    return res.has_value() ? res.value().has_value() : false;
+  }
+
+  void AudiStoreImpl::forEach(
+      std::function<void(const primitives::AuthorityDiscoveryId &,
+                         const AuthorityPeerInfo &)> f) const {
+    auto cursor = space_->cursor();
+    while (cursor->isValid()) {
+      auto key = cursor->key();
+      auto value = cursor->value();
+      if (not key or not value
+          or key.value().size() != primitives::AuthorityDiscoveryId::size()) {
+        std::ignore = cursor->next();
+        continue;
+      }
+      primitives::AuthorityDiscoveryId authority =
+          primitives::AuthorityDiscoveryId::fromSpan(key.value().toVector())
+              .value();
+      if (auto decoded = scale::decode<AuthorityPeerInfo>(value.value())) {
+        f(authority, decoded.value());
+      } else {
+        SL_ERROR(log_, "Failed to decode PeerInfo");
+      }
+      std::ignore = cursor->next();
+    }
+  }
+
+}  // namespace kagome::authority_discovery

--- a/core/authority_discovery/query/audi_store_impl.hpp
+++ b/core/authority_discovery/query/audi_store_impl.hpp
@@ -25,7 +25,8 @@ namespace kagome::authority_discovery {
     std::optional<AuthorityPeerInfo> get(
         const primitives::AuthorityDiscoveryId &authority) const override;
 
-    bool remove(const primitives::AuthorityDiscoveryId &authority) override;
+    outcome::result<void> remove(
+        const primitives::AuthorityDiscoveryId &authority) override;
 
     bool contains(
         const primitives::AuthorityDiscoveryId &authority) const override;
@@ -33,6 +34,9 @@ namespace kagome::authority_discovery {
     void forEach(
         std::function<void(const primitives::AuthorityDiscoveryId &,
                            const AuthorityPeerInfo &)> f) const override;
+
+    void retainIf(std::function<bool(const primitives::AuthorityDiscoveryId &,
+                                     const AuthorityPeerInfo &)> f) override;
 
    private:
     std::shared_ptr<storage::BufferBatchableStorage> space_;

--- a/core/authority_discovery/query/audi_store_impl.hpp
+++ b/core/authority_discovery/query/audi_store_impl.hpp
@@ -1,0 +1,42 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "authority_discovery/query/audi_store.hpp"
+#include "log/logger.hpp"
+#include "primitives/authority_discovery_id.hpp"
+#include "storage/spaced_storage.hpp"
+
+namespace kagome::authority_discovery {
+
+  class AudiStoreImpl : public AudiStore {
+   public:
+    explicit AudiStoreImpl(std::shared_ptr<storage::SpacedStorage> storage);
+
+    ~AudiStoreImpl() override = default;
+
+    void store(const primitives::AuthorityDiscoveryId &authority,
+               const AuthorityPeerInfo &data) override;
+
+    std::optional<AuthorityPeerInfo> get(
+        const primitives::AuthorityDiscoveryId &authority) const override;
+
+    bool remove(const primitives::AuthorityDiscoveryId &authority) override;
+
+    bool contains(
+        const primitives::AuthorityDiscoveryId &authority) const override;
+
+    void forEach(
+        std::function<void(const primitives::AuthorityDiscoveryId &,
+                           const AuthorityPeerInfo &)> f) const override;
+
+   private:
+    std::shared_ptr<storage::BufferBatchableStorage> space_;
+    log::Logger log_;
+  };
+
+}  // namespace kagome::authority_discovery

--- a/core/authority_discovery/query/authority_peer_info.hpp
+++ b/core/authority_discovery/query/authority_peer_info.hpp
@@ -11,6 +11,7 @@
 
 namespace kagome::authority_discovery {
   struct AuthorityPeerInfo {
+    SCALE_TIE(3);
     common::Buffer raw{};
     std::optional<TimestampScale> time{};
     scale::PeerInfoSerializable peer{};

--- a/core/authority_discovery/query/authority_peer_info.hpp
+++ b/core/authority_discovery/query/authority_peer_info.hpp
@@ -1,6 +1,8 @@
-//
-// Created by taisei on 03.12.2024.
-//
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 
@@ -8,14 +10,15 @@
 #include "authority_discovery/timestamp.hpp"
 #include "common/buffer.hpp"
 #include "scale/libp2p_types.hpp"
+#include "scale/tie.hpp"
 
 namespace kagome::authority_discovery {
   struct AuthorityPeerInfo {
     SCALE_TIE(3);
+
     common::Buffer raw{};
     std::optional<TimestampScale> time{};
     scale::PeerInfoSerializable peer{};
   };
-
 
 }  // namespace kagome::authority_discovery

--- a/core/authority_discovery/query/authority_peer_info.hpp
+++ b/core/authority_discovery/query/authority_peer_info.hpp
@@ -1,0 +1,31 @@
+//
+// Created by taisei on 03.12.2024.
+//
+
+#pragma once
+
+#include "authority_discovery/query/authority_peer_info.hpp"
+#include "authority_discovery/timestamp.hpp"
+#include "common/buffer.hpp"
+#include "scale/libp2p_types.hpp"
+
+namespace kagome::authority_discovery {
+  struct AuthorityPeerInfo {
+    common::Buffer raw{};
+    std::optional<TimestampScale> time{};
+    scale::PeerInfoSerializable peer{};
+  };
+
+  template <class Stream>
+    requires Stream::is_encoder_stream
+  Stream &operator<<(Stream &s, const AuthorityPeerInfo &api) {
+    return s << api.raw << api.time << api.peer;
+  }
+
+  template <class Stream>
+    requires Stream::is_decoder_stream
+  Stream &operator>>(Stream &s, AuthorityPeerInfo &api) {
+    return s >> api.raw >> api.time >> api.peer;
+  }
+
+}  // namespace kagome::authority_discovery

--- a/core/authority_discovery/query/authority_peer_info.hpp
+++ b/core/authority_discovery/query/authority_peer_info.hpp
@@ -17,16 +17,5 @@ namespace kagome::authority_discovery {
     scale::PeerInfoSerializable peer{};
   };
 
-  template <class Stream>
-    requires Stream::is_encoder_stream
-  Stream &operator<<(Stream &s, const AuthorityPeerInfo &api) {
-    return s << api.raw << api.time << api.peer;
-  }
-
-  template <class Stream>
-    requires Stream::is_decoder_stream
-  Stream &operator>>(Stream &s, AuthorityPeerInfo &api) {
-    return s >> api.raw >> api.time >> api.peer;
-  }
 
 }  // namespace kagome::authority_discovery

--- a/core/authority_discovery/query/query_impl.cpp
+++ b/core/authority_discovery/query/query_impl.cpp
@@ -41,6 +41,7 @@ namespace kagome::authority_discovery {
       std::shared_ptr<runtime::AuthorityDiscoveryApi> authority_discovery_api,
       LazySPtr<network::ValidationProtocol> validation_protocol,
       std::shared_ptr<crypto::KeyStore> key_store,
+      std::shared_ptr<AudiStore> audi_store,
       std::shared_ptr<crypto::Sr25519Provider> sr_crypto_provider,
       std::shared_ptr<libp2p::crypto::CryptoProvider> libp2p_crypto_provider,
       std::shared_ptr<libp2p::crypto::marshaller::KeyMarshaller> key_marshaller,
@@ -51,6 +52,7 @@ namespace kagome::authority_discovery {
         authority_discovery_api_{std::move(authority_discovery_api)},
         validation_protocol_{std::move(validation_protocol)},
         key_store_{std::move(key_store)},
+        audi_store_(std::move(audi_store)),
         sr_crypto_provider_{std::move(sr_crypto_provider)},
         libp2p_crypto_provider_{std::move(libp2p_crypto_provider)},
         key_marshaller_{std::move(key_marshaller)},
@@ -68,6 +70,7 @@ namespace kagome::authority_discovery {
         log_{log::createLogger("AuthorityDiscoveryQuery",
                                "authority_discovery")} {
     app_state_manager->takeControl(*this);
+    BOOST_ASSERT(audi_store_ != nullptr);
   }
 
   bool QueryImpl::start() {
@@ -83,11 +86,11 @@ namespace kagome::authority_discovery {
   std::optional<libp2p::peer::PeerInfo> QueryImpl::get(
       const primitives::AuthorityDiscoveryId &authority) const {
     std::unique_lock lock{mutex_};
-    auto it = auth_to_peer_cache_.find(authority);
-    if (it != auth_to_peer_cache_.end()) {
-      return it->second.peer;
+    auto authority_opt = audi_store_->get(authority);
+    if (authority_opt == std::nullopt) {
+      return std::nullopt;
     }
-    return std::nullopt;
+    return authority_opt.value().peer;
   }
 
   std::optional<primitives::AuthorityDiscoveryId> QueryImpl::get(
@@ -125,9 +128,9 @@ namespace kagome::authority_discovery {
       lock.unlock();
       return kademlia_validator_.select(key, values);
     }
-    auto it = auth_to_peer_cache_.find(*id);
-    if (it != auth_to_peer_cache_.end()) {
-      auto it_value = std::ranges::find(values, it->second.raw);
+    auto authority = audi_store_->get(*id);
+    if (authority != std::nullopt) {
+      auto it_value = std::ranges::find(values, authority.value().raw);
       if (it_value != values.end()) {
         return it_value - values.begin();
       }
@@ -155,14 +158,18 @@ namespace kagome::authority_discovery {
     retain_if(authorities, [&](const primitives::AuthorityDiscoveryId &id) {
       return not has(local_keys, id);
     });
-    for (auto it = auth_to_peer_cache_.begin();
-         it != auth_to_peer_cache_.end();) {
-      if (has(authorities, it->first)) {
-        ++it;
-      } else {
-        it = auth_to_peer_cache_.erase(it);
-        validation_protocol_.get()->reserve(it->second.peer.id, false);
+    // remove outdated authorities
+    std::deque<std::pair<primitives::AuthorityDiscoveryId, AuthorityPeerInfo>>
+        to_remove;
+    audi_store_->forEach([&](const primitives::AuthorityDiscoveryId &id,
+                             const AuthorityPeerInfo &info) {
+      if (not has(authorities, id)) {
+        to_remove.emplace_back(id, info);
       }
+    });
+    for (auto &pair : to_remove) {
+      audi_store_->remove(pair.first);
+      validation_protocol_.get()->reserve(pair.second.peer.id, false);
     }
     for (auto it = peer_to_auth_cache_.begin();
          it != peer_to_auth_cache_.end();) {
@@ -181,7 +188,7 @@ namespace kagome::authority_discovery {
     // `queue_` is a stack, so push known first
     for (auto &known : {true, false}) {
       for (auto &id : authorities) {
-        if (auth_to_peer_cache_.contains(id) == known) {
+        if (audi_store_->contains(id) == known) {
           queue_.emplace_back(id);
         }
       }
@@ -238,9 +245,8 @@ namespace kagome::authority_discovery {
              common::hex_lower(authority),
              _res.has_value() ? "ok" : "error: " + _res.error().message());
     OUTCOME_TRY(signed_record_pb, _res);
-    auto it = auth_to_peer_cache_.find(authority);
-    if (it != auth_to_peer_cache_.end()
-        and signed_record_pb == it->second.raw) {
+    auto it = audi_store_->get(authority);
+    if (it != std::nullopt and signed_record_pb == it->raw) {
       return outcome::success();
     }
     ::authority_discovery_v3::SignedAuthorityRecord signed_record;
@@ -281,12 +287,13 @@ namespace kagome::authority_discovery {
                   scale::decode<TimestampScale>(
                       qtils::str2byte(record.creation_time().timestamp())));
       time = *tmp;
-      if (it != auth_to_peer_cache_.end() and time <= it->second.time) {
+      if (it != std::nullopt and time <= it->time->number) {
         SL_TRACE(log_, "lookup: outdated record for authority {}", authority);
         return outcome::success();
       }
     }
-    libp2p::peer::PeerInfo peer{.id = std::move(peer_id)};
+    scale::PeerInfoSerializable peer;
+    peer.id = std::move(peer_id);
     auto peer_id_str = peer.id.toBase58();
     SL_TRACE(log_,
              "lookup: adding {} addresses for authority {}",
@@ -330,12 +337,14 @@ namespace kagome::authority_discovery {
         peer.id, peer.addresses, libp2p::peer::ttl::kDay);
 
     peer_to_auth_cache_.insert_or_assign(peer.id, authority);
-    auth_to_peer_cache_.insert_or_assign(authority,
-                                         Authority{
-                                             .raw = std::move(signed_record_pb),
-                                             .time = time,
-                                             .peer = peer,
-                                         });
+    audi_store_->store(
+        authority,
+        AuthorityPeerInfo{
+            .raw = std::move(signed_record_pb),
+            .time = time.has_value() ? std::make_optional<TimestampScale>(*time)
+                                     : std::nullopt,
+            .peer = peer,
+        });
 
     validation_protocol_.get()->reserve(peer.id, true);
 

--- a/core/authority_discovery/query/query_impl.cpp
+++ b/core/authority_discovery/query/query_impl.cpp
@@ -88,8 +88,15 @@ namespace kagome::authority_discovery {
     std::unique_lock lock{mutex_};
     auto authority_opt = audi_store_->get(authority);
     if (authority_opt == std::nullopt) {
+      SL_TRACE(log_,
+               "No authority peer found in storage {}",
+               common::hex_lower(authority));
       return std::nullopt;
     }
+    SL_TRACE(log_,
+             "Authority id {} {} addresses found in storage",
+             common::hex_lower(authority),
+             authority_opt.value().peer.addresses.size());
     return authority_opt.value().peer;
   }
 
@@ -287,7 +294,7 @@ namespace kagome::authority_discovery {
                   scale::decode<TimestampScale>(
                       qtils::str2byte(record.creation_time().timestamp())));
       time = *tmp;
-      if (it != std::nullopt and time <= it->time->number) {
+      if (it and it->time and time <= it->time->number) {
         SL_TRACE(log_, "lookup: outdated record for authority {}", authority);
         return outcome::success();
       }

--- a/core/authority_discovery/query/query_impl.hpp
+++ b/core/authority_discovery/query/query_impl.hpp
@@ -10,7 +10,7 @@
 
 #include "application/app_state_manager.hpp"
 #include "authority_discovery/interval.hpp"
-#include "authority_discovery/timestamp.hpp"
+#include "authority_discovery/query/audi_store.hpp"
 #include "blockchain/block_tree.hpp"
 #include "crypto/key_store.hpp"
 #include "crypto/sr25519_provider.hpp"
@@ -49,6 +49,7 @@ namespace kagome::authority_discovery {
         std::shared_ptr<runtime::AuthorityDiscoveryApi> authority_discovery_api,
         LazySPtr<network::ValidationProtocol> validation_protocol,
         std::shared_ptr<crypto::KeyStore> key_store,
+        std::shared_ptr<AudiStore> audi_store,
         std::shared_ptr<crypto::Sr25519Provider> sr_crypto_provider,
         std::shared_ptr<libp2p::crypto::CryptoProvider> libp2p_crypto_provider,
         std::shared_ptr<libp2p::crypto::marshaller::KeyMarshaller>
@@ -76,12 +77,6 @@ namespace kagome::authority_discovery {
     outcome::result<void> update();
 
    private:
-    struct Authority {
-      Buffer raw;
-      std::optional<Timestamp> time;
-      libp2p::peer::PeerInfo peer;
-    };
-
     std::optional<primitives::AuthorityDiscoveryId> hashToAuth(
         BufferView key) const;
     void pop();
@@ -92,6 +87,7 @@ namespace kagome::authority_discovery {
     std::shared_ptr<runtime::AuthorityDiscoveryApi> authority_discovery_api_;
     LazySPtr<network::ValidationProtocol> validation_protocol_;
     std::shared_ptr<crypto::KeyStore> key_store_;
+    std::shared_ptr<AudiStore> audi_store_;
     std::shared_ptr<crypto::Sr25519Provider> sr_crypto_provider_;
     std::shared_ptr<libp2p::crypto::CryptoProvider> libp2p_crypto_provider_;
     std::shared_ptr<libp2p::crypto::marshaller::KeyMarshaller> key_marshaller_;
@@ -104,8 +100,6 @@ namespace kagome::authority_discovery {
     std::default_random_engine random_;
     libp2p::protocol::kademlia::ValidatorDefault kademlia_validator_;
     std::unordered_map<Hash256, primitives::AuthorityDiscoveryId> hash_to_auth_;
-    std::unordered_map<primitives::AuthorityDiscoveryId, Authority>
-        auth_to_peer_cache_;
     std::unordered_map<libp2p::peer::PeerId, primitives::AuthorityDiscoveryId>
         peer_to_auth_cache_;
     std::vector<primitives::AuthorityDiscoveryId> queue_;

--- a/core/injector/application_injector.cpp
+++ b/core/injector/application_injector.cpp
@@ -51,6 +51,7 @@
 #include "application/modes/print_chain_info_mode.hpp"
 #include "application/modes/recovery_mode.hpp"
 #include "authority_discovery/publisher/address_publisher.hpp"
+#include "authority_discovery/query/audi_store_impl.hpp"
 #include "authority_discovery/query/query_impl.hpp"
 #include "authorship/impl/block_builder_factory_impl.hpp"
 #include "authorship/impl/block_builder_impl.hpp"
@@ -869,6 +870,7 @@ namespace {
             di::bind<telemetry::TelemetryService>.template to<telemetry::TelemetryServiceImpl>(),
             di::bind<api::InternalApi>.template to<api::InternalApiImpl>(),
             di::bind<consensus::babe::BabeConfigRepository>.template to<consensus::babe::BabeConfigRepositoryImpl>(),
+            di::bind<authority_discovery::AudiStore>.template to<authority_discovery::AudiStoreImpl>(),
             di::bind<authority_discovery::Query>.template to<authority_discovery::QueryImpl>(),
             di::bind<libp2p::protocol::kademlia::Validator>.template to<authority_discovery::QueryImpl>()[boost::di::override],
             di::bind<crypto::SessionKeys>.template to<crypto::SessionKeysImpl>(),

--- a/core/scale/kagome_scale.hpp
+++ b/core/scale/kagome_scale.hpp
@@ -22,6 +22,8 @@
 #include "scale/encode_append.hpp"
 #include "scale/libp2p_types.hpp"
 
+#include <authority_discovery/query/authority_peer_info.hpp>
+
 namespace kagome::scale {
   using CompactInteger = ::scale::CompactInteger;
   using BitVec = ::scale::BitVec;
@@ -89,6 +91,10 @@ namespace kagome::scale {
   template <typename F>
   constexpr void encode(const F &func,
                         const consensus::babe::BabeBlockHeader &bh);
+
+  template <typename F>
+  constexpr void encode(const F &func,
+                        const authority_discovery::AuthorityPeerInfo &c);
 
 }  // namespace kagome::scale
 
@@ -193,6 +199,14 @@ namespace kagome::scale {
   template <typename F>
   constexpr void encode(const F &func, const network::Roles &c) {
     encode(func, c.value);
+  }
+
+  template <typename F>
+  constexpr void encode(const F &func,
+                        const authority_discovery::AuthorityPeerInfo &c) {
+    encode(func, c.raw);
+    encode(func, c.time);
+    encode(func, c.peer);
   }
 
 }  // namespace kagome::scale

--- a/core/storage/rocksdb/rocksdb_spaces.cpp
+++ b/core/storage/rocksdb/rocksdb_spaces.cpp
@@ -6,8 +6,8 @@
 
 #include "storage/rocksdb/rocksdb_spaces.hpp"
 
-#include <array>
 #include <algorithm>
+#include <array>
 
 #include <rocksdb/db.h>
 #include <boost/assert.hpp>
@@ -22,7 +22,8 @@ namespace kagome::storage {
                                           "trie_value",
                                           "dispute_data",
                                           "beefy_justification",
-                                          "avaliability_storage"};
+                                          "avaliability_storage",
+                                          "audi_peers"};
 
   std::string spaceName(Space space) {
     static_assert(kSpaceNames.size() == Space::kTotal - 1);

--- a/core/storage/rocksdb/rocksdb_spaces.cpp
+++ b/core/storage/rocksdb/rocksdb_spaces.cpp
@@ -23,7 +23,8 @@ namespace kagome::storage {
                                           "dispute_data",
                                           "beefy_justification",
                                           "avaliability_storage",
-                                          "audi_peers"};
+                                          "audi_peers",
+                                        };
 
   std::string spaceName(Space space) {
     static_assert(kSpaceNames.size() == Space::kTotal - 1);

--- a/core/storage/spaces.hpp
+++ b/core/storage/spaces.hpp
@@ -24,6 +24,7 @@ namespace kagome::storage {
     kDisputeData,
     kBeefyJustification,
     kAvaliabilityStorage,
+    kAudiPeers,
 
     kTotal
   };


### PR DESCRIPTION
[//]: # (
Copyright Quadrivium LLC
All Rights Reserved
SPDX-License-Identifier: Apache-2.0
)

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch. -->

### Referenced issues

Closes #2300 

### Description of the Change

* Implements AudiStore that persistently stores discovered authority's peer information

### Possible Drawbacks

* DB-based audi store instead of in-memory
* Breaks compatibility

## Checklist Before Opening a PR

Before you open a Pull Request (PR), please make sure you've completed the following steps and confirm by answering 'Yes' to each item:

1. **Code is formatted**: Have you run your code through clang-format to ensure it adheres to the project's coding standards? **Yes**
2. **Code is documented**: Have you added comments and documentation to your code according to the guidelines in the project's [contributing guidelines](https://github.com/qdrvm/kagome/CONTRIBUTING.md)? **yes**
3. **Self-review**: Have you reviewed your own code to ensure it is free of typos, syntax errors, logical errors, and unresolved TODOs or FIXME without linking to an issue? **Yes**
4. **Zombienet Tests**: Have you ensured that the zombienet tests are passing? Zombienet is a network simulation and testing tool used in this project. It's important to ensure that these tests pass to maintain the stability and reliability of the project. **Yes**

<!-- Please answer 'Yes' to each of these items in your PR description to confirm that you've completed them. This will help maintain the quality of the project and facilitate efficient collaboration. -->

