### PR TITLE
Fix/align

### DIFF
--- a/core/network/impl/peer_manager_impl.cpp
+++ b/core/network/impl/peer_manager_impl.cpp
@@ -343,7 +343,8 @@ namespace kagome::network {
     // Not enough active peers
     if (countPeers(PeerType::PEER_TYPE_OUT) < app_config_.outPeers()) {
       if (not queue_to_connect_.empty()) {
-        for (;;) {
+        BOOST_ASSERT(queue_to_connect_.size() == peers_in_queue_.size());
+        while (not queue_to_connect_.empty() && not peers_in_queue_.empty()) {
           auto node = peers_in_queue_.extract(queue_to_connect_.front());
           auto &peer_id = node.value();
 

--- a/core/parachain/types.hpp
+++ b/core/parachain/types.hpp
@@ -221,7 +221,7 @@ namespace kagome::network {
 }  // namespace kagome::network
 
 namespace kagome::parachain::fragment {
-  enum UpgradeRestriction {
+  enum UpgradeRestriction : uint8_t {
     /// There is an upgrade restriction and there are no details about its
     /// specifics nor how long
     /// it could last.


### PR DESCRIPTION
[//]: # (
Copyright Quadrivium LLC
All Rights Reserved
SPDX-License-Identifier: Apache-2.0
)

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch. -->

### Referenced issues

None

### Description of the Change

Resolves two long lasting issues:
* Crash during `PeerManagerImpl::align`
* ` ProspectiveParachains  Staging para backing state failed.`

Kudos to @iceseer @igor-egorov for resolving

### Possible Drawbacks

None

## Checklist Before Opening a PR

Before you open a Pull Request (PR), please make sure you've completed the following steps and confirm by answering 'Yes' to each item:

1. **Code is formatted**: Have you run your code through clang-format to ensure it adheres to the project's coding standards? **[Yes|No]**
2. **Code is documented**: Have you added comments and documentation to your code according to the guidelines in the project's [contributing guidelines](https://github.com/qdrvm/kagome/CONTRIBUTING.md)? **[Yes|No]**
3. **Self-review**: Have you reviewed your own code to ensure it is free of typos, syntax errors, logical errors, and unresolved TODOs or FIXME without linking to an issue? **[Yes|No]**
4. **Zombienet Tests**: Have you ensured that the zombienet tests are passing? Zombienet is a network simulation and testing tool used in this project. It's important to ensure that these tests pass to maintain the stability and reliability of the project. **[Yes|No]**

<!-- Please answer 'Yes' to each of these items in your PR description to confirm that you've completed them. This will help maintain the quality of the project and facilitate efficient collaboration. -->

