### PR TITLE
fix block tree prune

### DIFF
--- a/core/blockchain/impl/block_tree_impl.cpp
+++ b/core/blockchain/impl/block_tree_impl.cpp
@@ -1283,9 +1283,6 @@ namespace kagome::blockchain {
         metric_best_block_height_->set(changes.reorg->common.number);
       }
     }
-    for (auto &block : changes.prune) {
-      OUTCOME_TRY(p.storage_->removeBlock(block.hash));
-    }
 
     std::vector<primitives::Extrinsic> extrinsics;
     std::vector<primitives::events::RemoveAfterFinalizationParams::HeaderInfo>


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- #1839 #1679 added `removeBlock` before `(optional)getBlockHeader` and `(optional)getBlockBody`.
- #2286 changed `(optional)getBlockHeader` to `getBlockHeader`, causing missing "Finalized block" log and stalled metric, because of early `removeBlock`.

### Possible Drawbacks