### PR TITLE
Delete redundant chunk removal from storage

### DIFF
--- a/core/parachain/availability/recovery/recovery_impl.cpp
+++ b/core/parachain/availability/recovery/recovery_impl.cpp
@@ -196,20 +196,21 @@ namespace kagome::parachain {
     if (auto indexed_key_pair_opt =
             session_keys_->getParaKeyPair(session->validators);
         indexed_key_pair_opt.has_value()) {
-      auto out_validator_index = indexed_key_pair_opt->second;
-      auto index_of_our_chunk = val2chunk(out_validator_index);
+      auto our_validator_index = indexed_key_pair_opt->second;
+      auto index_of_our_chunk = val2chunk(our_validator_index);
       auto min_chunks = _min.value();
 
       auto our_chunk = av_store_->getChunk(candidate_hash, index_of_our_chunk);
-
       if (not our_chunk.has_value()) {
         SL_WARN(logger_,
-                "Our node does not have a chunk which it must be have");
+                "Our chunk {}:{} not found",
+                candidate_hash,
+                index_of_our_chunk);
       } else {
         available_data_size = our_chunk->chunk.size() * min_chunks;
       }
     } else {
-      SL_WARN(logger_, "Cannot retrieve out validator index");
+      SL_WARN(logger_, "Cannot retrieve our validator index");
     }
 
     // Do recovery from backers strategy iff available


### PR DESCRIPTION
[//]: # (
Copyright Quadrivium LLC
All Rights Reserved
SPDX-License-Identifier: Apache-2.0
)

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch. -->

### Referenced issues

Fixes #2355 

### Description of the Change

* We were removing chunk from storage in case where we were only supposed to remove from in memory cache

### Possible Drawbacks

None

## Checklist Before Opening a PR

Before you open a Pull Request (PR), please make sure you've completed the following steps and confirm by answering 'Yes' to each item:

1. **Code is formatted**: Have you run your code through clang-format to ensure it adheres to the project's coding standards? **Yes**
2. **Code is documented**: Have you added comments and documentation to your code according to the guidelines in the project's [contributing guidelines](https://github.com/qdrvm/kagome/CONTRIBUTING.md)? **Yes**
3. **Self-review**: Have you reviewed your own code to ensure it is free of typos, syntax errors, logical errors, and unresolved TODOs or FIXME without linking to an issue? **Yes**
4. **Zombienet Tests**: Have you ensured that the zombienet tests are passing? Zombienet is a network simulation and testing tool used in this project. It's important to ensure that these tests pass to maintain the stability and reliability of the project. **[Yes|No]**

<!-- Please answer 'Yes' to each of these items in your PR description to confirm that you've completed them. This will help maintain the quality of the project and facilitate efficient collaboration. -->

