### PR TITLE
Set default precompilation threads to 4

### DIFF
--- a/core/application/impl/app_configuration_impl.hpp
+++ b/core/application/impl/app_configuration_impl.hpp
@@ -386,8 +386,7 @@ namespace kagome::application {
     std::optional<BenchmarkConfigSection> benchmark_config_;
     AllowUnsafeRpc allow_unsafe_rpc_ = AllowUnsafeRpc::kAuto;
     uint32_t parachain_runtime_instance_cache_size_ = 100;
-    uint32_t parachain_precompilation_thread_num_ =
-        std::thread::hardware_concurrency() / 2;
+    uint32_t parachain_precompilation_thread_num_ = 4;
     bool should_precompile_parachain_modules_{true};
     bool use_pvf_subprocess_{true};
     size_t pvf_max_workers_{


### PR DESCRIPTION
[//]: # (
Copyright Quadrivium LLC
All Rights Reserved
SPDX-License-Identifier: Apache-2.0
)

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * Branch must be rebased onto base branch. -->

### Referenced issues

Closes #2390 

### Description of the Change

Large number of CPU cores could lead to too high number of parallel parachain runtime precompilations which in turn could consume all RAM.
This PR set default amount of precompilation threads to 4 to avoid such issues. In future, smarter strategies for figuring out optimal number of precompilation threads could be developed

### Possible Drawbacks

Could be not optimal for fastest precompilation

## Checklist Before Opening a PR

Before you open a Pull Request (PR), please make sure you've completed the following steps and confirm by answering 'Yes' to each item:

1. **Code is formatted**: Have you run your code through clang-format to ensure it adheres to the project's coding standards? **Yes**
2. **Code is documented**: Have you added comments and documentation to your code according to the guidelines in the project's [contributing guidelines](https://github.com/qdrvm/kagome/CONTRIBUTING.md)? **Yes**
3. **Self-review**: Have you reviewed your own code to ensure it is free of typos, syntax errors, logical errors, and unresolved TODOs or FIXME without linking to an issue? **Yes**
4. **Zombienet Tests**: Have you ensured that the zombienet tests are passing? Zombienet is a network simulation and testing tool used in this project. It's important to ensure that these tests pass to maintain the stability and reliability of the project. **No**

<!-- Please answer 'Yes' to each of these items in your PR description to confirm that you've completed them. This will help maintain the quality of the project and facilitate efficient collaboration. -->

