### PR TITLE
ignore announce above executing block

### DIFF
--- a/core/network/impl/synchronizer_impl.cpp
+++ b/core/network/impl/synchronizer_impl.cpp
@@ -31,6 +31,7 @@
 #include "storage/trie/trie_storage.hpp"
 #include "storage/trie_pruner/trie_pruner.hpp"
 #include "utils/pool_handler_ready_make.hpp"
+#include "utils/sptr.hpp"
 #include "utils/weak_macro.hpp"
 
 OUTCOME_CPP_DEFINE_CATEGORY(kagome::network, SynchronizerImpl::Error, e) {
@@ -330,6 +331,16 @@ namespace kagome::network {
       const libp2p::peer::PeerId &peer_id,
       Synchronizer::SyncResultHandler &&handler) {
     const auto &block_info = header.blockInfo();
+
+    // ignore announces above currently executing block
+    if (timeline_.get()->wasSynchronized() and (SAFE_SHARED(executing_blocks_) {
+          return std::all_of(
+              executing_blocks_.begin(),
+              executing_blocks_.end(),
+              [&](const BlockInfo &x) { return header.number > x.number; });
+        })) {
+      return false;
+    }
 
     // Block was applied before
     if (block_tree_->has(block_info.hash)) {
@@ -1035,13 +1046,29 @@ namespace kagome::network {
         }
 
       } else {
-        auto callback = [WEAK_SELF, block_info, handler{std::move(handler)}](
-                            auto &&block_addition_result) mutable {
-          WEAK_LOCK(self);
-          self->post_block_addition(std::move(block_addition_result),
-                                    std::move(handler),
-                                    block_info.hash);
+        SAFE_UNIQUE(executing_blocks_) {
+          executing_blocks_.emplace(block_info);
         };
+        auto remove_executing_blocks =
+            toSptr(libp2p::common::MovableFinalAction{[WEAK_SELF, block_info] {
+              WEAK_LOCK(self);
+              auto &executing_blocks_ = self->executing_blocks_;
+              SAFE_UNIQUE(executing_blocks_) {
+                executing_blocks_.erase(block_info);
+              };
+            }});
+        auto callback =
+            [WEAK_SELF,
+             block_info,
+             handler{std::move(handler)},
+             remove_executing_blocks{std::move(remove_executing_blocks)}](
+                auto &&block_addition_result) mutable {
+              WEAK_LOCK(self);
+              remove_executing_blocks.reset();
+              self->post_block_addition(std::move(block_addition_result),
+                                        std::move(handler),
+                                        block_info.hash);
+            };
 
         if (sync_method_ == application::SyncMethod::Full) {
           // Check if body is present

--- a/core/network/impl/synchronizer_impl.cpp
+++ b/core/network/impl/synchronizer_impl.cpp
@@ -334,7 +334,7 @@ namespace kagome::network {
 
     // ignore announces above currently executing block
     if (timeline_.get()->wasSynchronized() and (SAFE_SHARED(executing_blocks_) {
-          return std::all_of(
+          return std::ranges::all_of(
               executing_blocks_.begin(),
               executing_blocks_.end(),
               [&](const BlockInfo &x) { return header.number > x.number; });

--- a/core/network/impl/synchronizer_impl.hpp
+++ b/core/network/impl/synchronizer_impl.hpp
@@ -97,7 +97,7 @@ namespace kagome::network {
         kMinPreloadedBlockAmount * 2;
 
     static constexpr std::chrono::milliseconds kRecentnessDuration =
-        std::chrono::seconds(60);
+        std::chrono::minutes{2};
 
     enum class Error {
       SHUTTING_DOWN = 1,

--- a/core/network/impl/synchronizer_impl.hpp
+++ b/core/network/impl/synchronizer_impl.hpp
@@ -30,6 +30,7 @@
 #include "primitives/event_types.hpp"
 #include "storage/spaced_storage.hpp"
 #include "telemetry/service.hpp"
+#include "utils/safe_object.hpp"
 
 namespace kagome {
   class PoolHandlerReady;
@@ -73,6 +74,8 @@ namespace kagome::storage::trie_pruner {
 }
 
 namespace kagome::network {
+  using primitives::BlockInfo;
+
   class SynchronizerImpl
       : public Synchronizer,
         public std::enable_shared_from_this<SynchronizerImpl> {
@@ -323,6 +326,7 @@ namespace kagome::network {
     std::map<std::tuple<libp2p::peer::PeerId, BlocksRequest::Fingerprint>,
              const char *>
         recent_requests_;
+    SafeObject<std::unordered_set<BlockInfo>> executing_blocks_;
   };
 
 }  // namespace kagome::network


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- context: 2 blocks were simultaneously executing for 85 seconds, then sync stopped (most peers didn't respond to findCommonBlock and loadBlocks).
- after first successful sync, ignore block announces above currently executing blocks

### Possible Drawbacks