### PR TITLE
fix grandpa role

### DIFF
--- a/core/network/types/roles.hpp
+++ b/core/network/types/roles.hpp
@@ -26,16 +26,16 @@ namespace kagome::network {
 
     // https://github.com/paritytech/polkadot-sdk/blob/6c3219ebe9231a0305f53c7b33cb558d46058062/substrate/client/network/common/src/role.rs#L101
     bool isFull() const {
-      return (value_ & Full) or (value_ & Authority);
+      return (value_ & (Full | Authority)) != 0;
     }
 
     bool isAuthority() const {
-      return value_ & Authority;
+      return (value_ & Authority) != 0;
     }
 
     // https://github.com/paritytech/polkadot-sdk/blob/6c3219ebe9231a0305f53c7b33cb558d46058062/substrate/client/network/common/src/role.rs#L111
     bool isLight() const {
-      return not(value_ & Full);
+      return not isFull();
     }
 
     uint8_t value() const {


### PR DESCRIPTION
### Referenced issues
- #2379

### Description of the Change
`isLight` became broken during refactoring ("bit.full or bit.authority" -> "bit.full").
Grandpa used `isLight` to avoid sending votes and neighbor messages to light clients (`GrandpaProtocol::vote`, `GrandpaProtocol::neighbor`).
Broken `isLight(authority) == true` prevented sending votes and neighbor messages to authorities.

### Possible Drawbacks
Finalization can still be stuck with "Found best chain is longer than approved" message, unrelated to this PR