### PR TITLE
peer view miss event

### DIFF
--- a/core/network/impl/peer_view.cpp
+++ b/core/network/impl/peer_view.cpp
@@ -92,9 +92,6 @@ namespace kagome::network {
         .new_head = header,
         .lost = {},
     };
-    if (event.view == my_view_) {
-      return;
-    }
     my_view_stripped_ = std::move(stripped_view);
     for (const auto &head : my_view_.heads_) {
       if (not event.view.contains(head)) {

--- a/core/network/impl/protocols/parachain.cpp
+++ b/core/network/impl/protocols/parachain.cpp
@@ -116,6 +116,10 @@ namespace kagome::network {
   }
 
   void ParachainProtocol::write(const View &view) {
+    if (view == last_sent_view_) {
+      return;
+    }
+    last_sent_view_ = view;
     auto message = encodeView(view);
     notifications_->peersOut([&](const PeerId &peer_id, size_t protocol_group) {
       notifications_->write(peer_id, protocol_group, message);

--- a/core/network/impl/protocols/parachain.hpp
+++ b/core/network/impl/protocols/parachain.hpp
@@ -23,7 +23,6 @@ namespace kagome::network {
   class PeerView;
   struct Seconded;
   class ValidationObserver;
-  struct View;
 }  // namespace kagome::network
 
 namespace kagome::network {
@@ -76,6 +75,7 @@ namespace kagome::network {
     primitives::events::SyncStateSubscriptionEnginePtr sync_engine_;
     std::shared_ptr<void> sync_sub_;
     std::shared_ptr<void> my_view_sub_;
+    View last_sent_view_;
     // NOLINTEND(cppcoreguidelines-non-private-member-variables-in-classes)
   };
 


### PR DESCRIPTION
### Referenced issues

### Description of the Change
- caused "Found best chain is longer than approved" error, because parachains didn't get `kViewUpdated` event.
- `kNewHeads` is called once for each block, so event is never duplicate
- data race, 2 blocks became head before first event, so heads didn't change between first and second event, so second event was ignored

### Possible Drawbacks