### PR TITLE
pvf empty free workers

### DIFF
--- a/core/parachain/pvf/workers.hpp
+++ b/core/parachain/pvf/workers.hpp
@@ -9,7 +9,6 @@
 #include <deque>
 #include <filesystem>
 #include <list>
-#include <mutex>
 
 #include "metrics/metrics.hpp"
 #include "parachain/pvf/pvf_worker_types.hpp"
@@ -85,7 +84,6 @@ namespace kagome::parachain {
     size_t max_;
     PvfWorkerInputConfig worker_config_;
     std::list<Worker> free_;
-    mutable std::mutex free_mutex_;  // Mutex for protecting free_ list
     size_t used_ = 0;
     std::unordered_map<PvfExecTimeoutKind, std::deque<Job>> queues_;
 


### PR DESCRIPTION
### Referenced issues
- #2305

### Description of the Change
- Before #2305 `deque` was called after adding 1 free worker, to use it for at most 1 job from single queue. After, `deque` iterated multiple queues, but didn't check if there were more free workers after first iteration.
- Removed unused mutex, because all functions are called on main `io_context` thread

### Possible Drawbacks
